### PR TITLE
DocBlock comment fix

### DIFF
--- a/src/Reader/Entry/Atom.php
+++ b/src/Reader/Entry/Atom.php
@@ -104,7 +104,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get the entry creation date
      *
-     * @return string
+     * @return \DateTime
      */
     public function getDateCreated()
     {
@@ -122,7 +122,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get the entry modification date
      *
-     * @return string
+     * @return \DateTime
      */
     public function getDateModified()
     {

--- a/src/Reader/Entry/EntryInterface.php
+++ b/src/Reader/Entry/EntryInterface.php
@@ -38,14 +38,14 @@ interface EntryInterface
     /**
      * Get the entry creation date
      *
-     * @return string
+     * @return \DateTime
      */
     public function getDateCreated();
 
     /**
      * Get the entry modification date
      *
-     * @return string
+     * @return \DateTime
      */
     public function getDateModified();
 

--- a/src/Reader/Entry/Rss.php
+++ b/src/Reader/Entry/Rss.php
@@ -167,7 +167,7 @@ class Rss extends AbstractEntry implements EntryInterface
     /**
      * Get the entry's date of creation
      *
-     * @return string
+     * @return \DateTime
      */
     public function getDateCreated()
     {
@@ -178,7 +178,7 @@ class Rss extends AbstractEntry implements EntryInterface
      * Get the entry's date of modification
      *
      * @throws Exception\RuntimeException
-     * @return string
+     * @return \DateTime
      */
     public function getDateModified()
     {


### PR DESCRIPTION
My IDE automatically said I was being returned a string, so I was passing it into a new DateTime object, causing an error, as it was actually a DateTime object being returned. I have updated the relevant docblocks.
