### PR TITLE
Move zend-servicemanager to 'require' in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-escaper": "~2.5",
+        "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-stdlib": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-db": "~2.5",
         "zendframework/zend-cache": "~2.5",
         "zendframework/zend-http": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"


### PR DESCRIPTION
Fixes fatal error "Class 'Zend\ServiceManager\AbstractPluginManager'
not found"  when used as a stand-alone component.

Same issue as https://github.com/zendframework/zend-barcode/pull/5
