### PR TITLE
Implement StandaloneExtensionManager for Writer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "zendframework/zend-db": "~2.5",
         "zendframework/zend-cache": "~2.5",
         "zendframework/zend-http": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
@@ -30,7 +29,7 @@
         "zendframework/zend-cache": "Zend\\Cache component",
         "zendframework/zend-db": "Zend\\Db component",
         "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for default/recommended ExtensionManager implementations",
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
         "zendframework/zend-validator": "Zend\\Validator component"
     },
     "minimum-stability": "dev",

--- a/src/Writer/Extension/ITunes/Feed.php
+++ b/src/Writer/Extension/ITunes/Feed.php
@@ -14,8 +14,6 @@ use Zend\Feed\Writer;
 use Zend\Stdlib\StringUtils;
 use Zend\Stdlib\StringWrapper\StringWrapperInterface;
 
-/**
-*/
 class Feed
 {
     /**

--- a/src/Writer/ExtensionManager.php
+++ b/src/Writer/ExtensionManager.php
@@ -12,7 +12,7 @@ namespace Zend\Feed\Writer;
 /**
  * Default implementation of ExtensionManagerInterface
  *
- * Decorator of ExtensionPluginManager.
+ * Decorator for an ExtensionManagerInstance.
  */
 class ExtensionManager implements ExtensionManagerInterface
 {
@@ -22,14 +22,14 @@ class ExtensionManager implements ExtensionManagerInterface
      * Constructor
      *
      * Seeds the extension manager with a plugin manager; if none provided,
-     * creates an instance.
+     * creates and decorates an instance of StandaloneExtensionManager.
      *
-     * @param  null|ExtensionPluginManager $pluginManager
+     * @param  null|ExtensionManagerInterface $pluginManager
      */
-    public function __construct(ExtensionPluginManager $pluginManager = null)
+    public function __construct(ExtensionManagerInterface $pluginManager = null)
     {
         if (null === $pluginManager) {
-            $pluginManager = new ExtensionPluginManager();
+            $pluginManager = new StandaloneExtensionManager();
         }
         $this->pluginManager = $pluginManager;
     }
@@ -37,7 +37,7 @@ class ExtensionManager implements ExtensionManagerInterface
     /**
      * Method overloading
      *
-     * Proxy to composed ExtensionPluginManager instance.
+     * Proxy to composed ExtensionManagerInterface instance.
      *
      * @param  string $method
      * @param  array $args

--- a/src/Writer/StandaloneExtensionManager.php
+++ b/src/Writer/StandaloneExtensionManager.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Writer;
+
+class StandaloneExtensionManager implements ExtensionManagerInterface
+{
+    private $extensions = [
+        'Atom\Renderer\Feed'           => Extension\Atom\Renderer\Feed::class,
+        'Content\Renderer\Entry'       => Extension\Content\Renderer\Entry::class,
+        'DublinCore\Renderer\Entry'    => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCore\Renderer\Feed'     => Extension\DublinCore\Renderer\Feed::class,
+        'ITunes\Entry'                 => Extension\ITunes\Entry::class,
+        'ITunes\Feed'                  => Extension\ITunes\Feed::class,
+        'ITunes\Renderer\Entry'        => Extension\ITunes\Renderer\Entry::class,
+        'ITunes\Renderer\Feed'         => Extension\ITunes\Renderer\Feed::class,
+        'Slash\Renderer\Entry'         => Extension\Slash\Renderer\Entry::class,
+        'Threading\Renderer\Entry'     => Extension\Threading\Renderer\Entry::class,
+        'WellFormedWeb\Renderer\Entry' => Extension\WellFormedWeb\Renderer\Entry::class,
+    ];
+
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension)
+    {
+        return array_key_exists($extension, $this->extensions);
+    }
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return mixed
+     */
+    public function get($extension)
+    {
+        $class = $this->extensions[$extension];
+        return new $class();
+    }
+}

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -105,13 +105,16 @@ class Writer
                 return;
             }
         }
-        if (!$manager->has($feedName)
-            && !$manager->has($entryName)
-            && !$manager->has($feedRendererName)
-            && !$manager->has($entryRendererName)
+        if (! $manager->has($feedName)
+            && ! $manager->has($entryName)
+            && ! $manager->has($feedRendererName)
+            && ! $manager->has($entryRendererName)
         ) {
-            throw new Exception\RuntimeException('Could not load extension: ' . $name
-                . 'using Plugin Loader. Check prefix paths are configured and extension exists.');
+            throw new Exception\RuntimeException(sprintf(
+                'Could not load extension "%s" using Plugin Loader. '
+                . 'Check prefix paths are configured and extension exists.',
+                $name
+            ));
         }
         if ($manager->has($feedName)) {
             static::$extensions['feed'][] = $feedName;


### PR DESCRIPTION
Just as we did with the Reader subcomponent, this patch implements a `StandaloneExtensionManager` implementation of the `ExtensionManagerInterface` for the Writer subcomponent. `ExtensionManager` now composes one of these by default, decorating it.

This allows us to entirely remove the zend-servicemanager requirement even from the development dependencies!

Replaces #9.
