### PR TITLE
Fully separate HTTP client requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "zendframework/zend-http": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "~4.0",
+        "psr/http-message": "^1.0"
     },
     "suggest": {
         "zendframework/zend-cache": "Zend\\Cache component",

--- a/src/Reader/Exception/InvalidHttpClientException.php
+++ b/src/Reader/Exception/InvalidHttpClientException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Exception;
+
+use Zend\Feed\Exception;
+
+class InvalidHttpClientException extends Exception\InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Reader/Http/HeaderAwareClientInterface.php
+++ b/src/Reader/Http/HeaderAwareClientInterface.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Feed\Reader\Http;
 
-interface HeaderAwareClientInterface
+interface HeaderAwareClientInterface extends ClientInterface
 {
     /**
      * Allow specifying headers to use when fetching a feed.

--- a/src/Reader/Http/HeaderAwareClientInterface.php
+++ b/src/Reader/Http/HeaderAwareClientInterface.php
@@ -27,6 +27,7 @@ interface HeaderAwareClientInterface extends ClientInterface
      *
      * @param string $uri
      * @param array $headers
+     * @return HeaderAwareResponseInterface
      */
     public function get($uri, array $headers = []);
 }

--- a/src/Reader/Http/HeaderAwareClientInterface.php
+++ b/src/Reader/Http/HeaderAwareClientInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+interface HeaderAwareClientInterface
+{
+    /**
+     * Allow specifying headers to use when fetching a feed.
+     *
+     * Headers MUST be in the format:
+     *
+     * <code>
+     * [
+     *     'header-name' => [
+     *         'header',
+     *         'values'
+     *     ]
+     * ]
+     * </code>
+     *
+     * @param string $uri
+     * @param array $headers
+     */
+    public function get($uri, array $headers = []);
+}

--- a/src/Reader/Http/HeaderAwareResponseInterface.php
+++ b/src/Reader/Http/HeaderAwareResponseInterface.php
@@ -12,7 +12,7 @@ namespace Zend\Feed\Reader\Http;
 interface HeaderAwareResponseInterface extends ResponseInterface
 {
     /**
-     * Retrieve a header from the response.
+     * Retrieve a header (as a single line) from the response.
      *
      * Header name lookups MUST be case insensitive.
      *
@@ -24,5 +24,5 @@ interface HeaderAwareResponseInterface extends ResponseInterface
      * @param mixed $default Default value to use if header is not present.
      * @return string
      */
-    public function getHeader($name, $default = null);
+    public function getHeaderLine($name, $default = null);
 }

--- a/src/Reader/Http/HeaderAwareResponseInterface.php
+++ b/src/Reader/Http/HeaderAwareResponseInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+interface HeaderAwareResponseInterface extends ResponseInterface
+{
+    /**
+     * Retrieve a header from the response.
+     *
+     * Header name lookups MUST be case insensitive.
+     *
+     * Since the only header values the feed reader consumes are singular
+     * in nature, this method is expected to return a string, and not
+     * an array of values.
+     *
+     * @param string $name Header name to retrieve.
+     * @param mixed $default Default value to use if header is not present.
+     * @return string
+     */
+    public function getHeader($name, $default = null);
+}

--- a/src/Reader/Http/Psr7ResponseDecorator.php
+++ b/src/Reader/Http/Psr7ResponseDecorator.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
+
+/**
+ * ResponseInterface wrapper for a PSR-7 response.
+ */
+class Psr7ResponseDecorator implements HeaderAwareResponseInterface
+{
+    /**
+     * @var Psr7ResponseInterface
+     */
+    private $decoratedResponse;
+
+    /**
+     * @param Psr7ResponseInterface $response
+     */
+    public function __construct(Psr7ResponseInterface $response)
+    {
+        $this->decoratedResponse = $response;
+    }
+
+    /**
+     * Return the original PSR-7 response being decorated.
+     *
+     * @return Psr7ResponseInterface
+     */
+    public function getDecoratedResponse()
+    {
+        return $this->decoratedResponse;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBody()
+    {
+        return (string) $this->decoratedResponse->getBody();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStatusCode()
+    {
+        return $this->decoratedResponse->getStatusCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeaderLine($name, $default = null)
+    {
+        if (! $this->decoratedResponse->hasHeader($name)) {
+            return $default;
+        }
+        return $this->decoratedResponse->getHeaderLine($name);
+    }
+}

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+use Zend\Feed\Reader\Exception;
+
+class Response implements HeaderAwareResponseInterface
+{
+    /**
+     * @var string
+     */
+    private $body;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @param int $statusCode
+     * @param string|object $body
+     * @param array $headers
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($statusCode, $body = '', array $headers = [])
+    {
+        $this->validateStatusCode($statusCode);
+        $this->validateBody($body);
+        $this->validateHeaders($headers);
+
+        $this->statusCode = (int) $statusCode;
+        $this->body       = (string) $body;
+        $this->headers    = $this->normalizeHeaders($headers);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeader($name, $default = null)
+    {
+        $normalizedName = strtolower($name);
+        return isset($this->headers[$normalizedName])
+            ? $this->headers[$normalizedName]
+            : $default;
+    }
+
+    /**
+     * Validate that we have a status code argument that will work for our context.
+     *
+     * @param mixed $body
+     * @throws Exception\InvalidArgumentException for arguments not castable
+     *     to integer HTTP status codes.
+     */
+    private function validateStatusCode($statusCode)
+    {
+        if (! is_numeric($statusCode)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a numeric status code; received %s',
+                __CLASS__,
+                (is_object($statusCode) ? get_class($statusCode) : gettype($statusCode))
+            ));
+        }
+
+        if (100 > $statusCode || 599 < $statusCode) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an integer status code between 100 and 599 inclusive; received %s',
+                __CLASS__,
+                $statusCode
+            ));
+        }
+
+        if (intval($statusCode) != $statusCode) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an integer status code; received %s',
+                __CLASS__,
+                $statusCode
+            ));
+        }
+    }
+
+    /**
+     * Validate that we have a body argument that will work for our context.
+     *
+     * @param mixed $body
+     * @throws Exception\InvalidArgumentException for arguments not castable
+     *     to strings.
+     */
+    private function validateBody($body)
+    {
+        if (is_string($body)) {
+            return;
+        }
+
+        if (is_object($body) && method_exists($body, '__toString')) {
+            return;
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            '%s expects a string body, or an object that can cast to string; received %s',
+            __CLASS__,
+            (is_object($statusCode) ? get_class($statusCode) : gettype($statusCode))
+        ));
+    }
+
+    /**
+     * Validate header values.
+     *
+     * @param array $headers
+     * @throws Exception\InvalidArgumentException
+     */
+    private function validateHeaders(array $headers)
+    {
+        foreach ($headers as $name => $value) {
+            if (! is_string($name) || is_numeric($name) || empty($name)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Header names provided to %s must be non-empty, non-numeric strings; received %s',
+                    __CLASS__,
+                    $name
+                ));
+            }
+
+            if (! is_string($value)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Individual header values provided to %s must be strings; received %s for header %s',
+                    __CLASS__,
+                    (is_object($value) ? get_class($value) : gettype($value)),
+                    $name
+                ));
+            }
+        }
+    }
+
+    /**
+     * Normalize header names to lowercase.
+     *
+     * @param array $headers
+     * @return array
+     */
+    private function normalizeHeaders(array $headers)
+    {
+        $normalized = [];
+        foreach ($headers as $name => $value) {
+            $normalized[strtolower($name)] = $value;
+        }
+        return $normalized;
+    }
+}

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -64,7 +64,7 @@ class Response implements HeaderAwareResponseInterface
     /**
      * {@inheritDoc}
      */
-    public function getHeader($name, $default = null)
+    public function getHeaderLine($name, $default = null)
     {
         $normalizedName = strtolower($name);
         return isset($this->headers[$normalizedName])

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -126,7 +126,7 @@ class Response implements HeaderAwareResponseInterface
         throw new Exception\InvalidArgumentException(sprintf(
             '%s expects a string body, or an object that can cast to string; received %s',
             __CLASS__,
-            (is_object($statusCode) ? get_class($statusCode) : gettype($statusCode))
+            (is_object($body) ? get_class($body) : gettype($body))
         ));
     }
 
@@ -147,9 +147,9 @@ class Response implements HeaderAwareResponseInterface
                 ));
             }
 
-            if (! is_string($value)) {
+            if (! is_string($value) && ! is_numeric($value)) {
                 throw new Exception\InvalidArgumentException(sprintf(
-                    'Individual header values provided to %s must be strings; received %s for header %s',
+                    'Individual header values provided to %s must be a string or numeric; received %s for header %s',
                     __CLASS__,
                     (is_object($value) ? get_class($value) : gettype($value)),
                     $name

--- a/src/Reader/Http/ZendHttpClientDecorator.php
+++ b/src/Reader/Http/ZendHttpClientDecorator.php
@@ -29,6 +29,14 @@ class ZendHttpClientDecorator implements HeaderAwareClientInterface
     }
 
     /**
+     * @return ZendHttpClient
+     */
+    public function getDecoratedClient()
+    {
+        return $this->client;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function get($uri, array $headers = [])

--- a/src/Reader/Http/ZendHttpClientDecorator.php
+++ b/src/Reader/Http/ZendHttpClientDecorator.php
@@ -13,9 +13,7 @@ use Zend\Http\Client as ZendHttpClient;
 use Zend\Http\Headers;
 use Zend\Feed\Reader\Exception;
 
-class ZendHttpClientDecorator implements
-    ClientInterface,
-    HeaderAwareClientInterface
+class ZendHttpClientDecorator implements HeaderAwareClientInterface
 {
     /**
      * @var ZendHttpClient

--- a/src/Reader/Http/ZendHttpClientDecorator.php
+++ b/src/Reader/Http/ZendHttpClientDecorator.php
@@ -56,8 +56,8 @@ class ZendHttpClientDecorator implements HeaderAwareClientInterface
      */
     private function injectHeaders(array $headerValues)
     {
-        $headers = $this->client->getHeaders();
-        foreach ($headerValue as $name => $values) {
+        $headers = $this->client->getRequest()->getHeaders();
+        foreach ($headerValues as $name => $values) {
             if (! is_string($name) || is_numeric($name) || empty($name)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Header names provided to %s::get must be non-empty, non-numeric strings; received %s',
@@ -75,9 +75,10 @@ class ZendHttpClientDecorator implements HeaderAwareClientInterface
             }
 
             foreach ($values as $value) {
-                if (! is_string($value)) {
+                if (! is_string($value) && ! is_numeric($value)) {
                     throw new Exception\InvalidArgumentException(sprintf(
-                        'Individual header values provided to %s::get must be strings; received %s for header %s',
+                        'Individual header values provided to %s::get must be strings or numbers; '
+                        . 'received %s for header %s',
                         __CLASS__,
                         (is_object($value) ? get_class($value) : gettype($value)),
                         $name

--- a/src/Reader/Http/ZendHttpClientDecorator.php
+++ b/src/Reader/Http/ZendHttpClientDecorator.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+use Zend\Http\Client as ZendHttpClient;
+use Zend\Http\Headers;
+use Zend\Feed\Reader\Exception;
+
+class ZendHttpClientDecorator implements
+    ClientInterface,
+    HeaderAwareClientInterface
+{
+    /**
+     * @var ZendHttpClient
+     */
+    private $client;
+
+    /**
+     * @param ZendHttpClient $client
+     */
+    public function __construct(ZendHttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($uri, array $headers = [])
+    {
+        $this->client->resetParameters();
+        $this->client->setMethod('GET');
+        $this->client->setHeaders(new Headers());
+        $this->client->setUri($uri);
+        if (! empty($headers)) {
+            $this->injectHeaders($headers);
+        }
+        $response = $this->client->send();
+
+        return new Response(
+            $response->getStatusCode(),
+            $response->getBody(),
+            $this->prepareResponseHeaders($response->getHeaders())
+        );
+    }
+
+    /**
+     * Inject header values into the client.
+     *
+     * @param array $headerValues
+     */
+    private function injectHeaders(array $headerValues)
+    {
+        $headers = $this->client->getHeaders();
+        foreach ($headerValue as $name => $values) {
+            if (! is_string($name) || is_numeric($name) || empty($name)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Header names provided to %s::get must be non-empty, non-numeric strings; received %s',
+                    __CLASS__,
+                    $name
+                ));
+            }
+
+            if (! is_array($values)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Header values provided to %s::get must be arrays of values; received %s',
+                    __CLASS__,
+                    (is_object($values) ? get_class($values) : gettype($values))
+                ));
+            }
+
+            foreach ($values as $value) {
+                if (! is_string($value)) {
+                    throw new Exception\InvalidArgumentException(sprintf(
+                        'Individual header values provided to %s::get must be strings; received %s for header %s',
+                        __CLASS__,
+                        (is_object($value) ? get_class($value) : gettype($value)),
+                        $name
+                    ));
+                }
+
+                $headers->addHeaderLine($name, $value);
+            }
+        }
+    }
+
+    /**
+     * Normalize headers to use with HeaderAwareResponseInterface.
+     *
+     * Ensures multi-value headers are represented as a single string, via
+     * comma concatenation.
+     *
+     * @param Headers $headers
+     * @return array
+     */
+    private function prepareResponseHeaders(Headers $headers)
+    {
+        $normalized = [];
+        foreach ($headers->toArray() as $name => $value) {
+            $normalized[$name] = is_array($value) ? implode(', ', $value) : $value;
+        }
+        return $normalized;
+    }
+}

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -228,11 +228,11 @@ class Reader implements ReaderImportInterface
                 $hasHeaders  = $response instanceof Http\HeaderAwareResponseInterface;
                 $responseXml = $response->getBody();
                 $cache->setItem($cacheId, $responseXml);
-                if ($hasHeaders && $response->getHeader('ETag', false)) {
-                    $cache->setItem($cacheId . '_etag', $response->getHeader('ETag'));
+                if ($hasHeaders && $response->getHeaderLine('ETag', false)) {
+                    $cache->setItem($cacheId . '_etag', $response->getHeaderLine('ETag'));
                 }
-                if ($hasHeaders && $response->getHeader('Last-Modified', false)) {
-                    $cache->setItem($cacheId . '_lastmodified', $response->getHeader('Last-Modified'));
+                if ($hasHeaders && $response->getHeaderLine('Last-Modified', false)) {
+                    $cache->setItem($cacheId . '_lastmodified', $response->getHeaderLine('Last-Modified'));
                 }
             }
             return static::importString($responseXml);

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -13,6 +13,7 @@ use DOMDocument;
 use DOMXPath;
 use Zend\Cache\Storage\StorageInterface as CacheStorage;
 use Zend\Http as ZendHttp;
+use Zend\Feed\Reader\Http\ClientInterface;
 use Zend\Stdlib\ErrorHandler;
 
 /**
@@ -57,7 +58,7 @@ class Reader implements ReaderImportInterface
     /**
      * HTTP client object to use for retrieving feeds
      *
-     * @var ZendHttp\Client
+     * @var ZendHttp\Client | ClientInterface
      */
     protected static $httpClient = null;
 
@@ -117,10 +118,10 @@ class Reader implements ReaderImportInterface
      *
      * Sets the HTTP client object to use for retrieving the feeds.
      *
-     * @param  ZendHttp\Client $httpClient
+     * @param  ZendHttp\Client | ClientInterface $httpClient
      * @return void
      */
-    public static function setHttpClient(ZendHttp\Client $httpClient)
+    public static function setHttpClient($httpClient)
     {
         static::$httpClient = $httpClient;
     }
@@ -128,11 +129,11 @@ class Reader implements ReaderImportInterface
     /**
      * Gets the HTTP client object. If none is set, a new ZendHttp\Client will be used.
      *
-     * @return ZendHttp\Client
+     * @return ZendHttp\Client | ClientInterface
      */
     public static function getHttpClient()
     {
-        if (!static::$httpClient instanceof ZendHttp\Client) {
+        if (!static::$httpClient instanceof ZendHttp\Client || !static::$httpClient instanceof ClientInterface) {
             static::$httpClient = new ZendHttp\Client();
         }
 

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -140,7 +140,7 @@ class Reader implements ReaderImportInterface
      */
     public static function getHttpClient()
     {
-        if (! static::$httpClient instanceof Http\ClientInterface) {
+        if (! static::$httpClient) {
             static::$httpClient = new Http\ZendHttpClientDecorator(new ZendHttp\Client());
         }
 

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -15,6 +15,7 @@ use Zend\Cache\Storage\StorageInterface as CacheStorage;
 use Zend\Http as ZendHttp;
 use Zend\Feed\Reader\Http\ClientInterface;
 use Zend\Stdlib\ErrorHandler;
+use Zend\Feed\Reader\Exception\InvalidHttpClientException;
 
 /**
 */
@@ -123,7 +124,10 @@ class Reader implements ReaderImportInterface
      */
     public static function setHttpClient($httpClient)
     {
-        static::$httpClient = $httpClient;
+        if (! $httpClient instanceof ZendHttp\Client || ! $httpClient instanceof ClientInterface) {
+            throw InvalidHttpClientException();
+        }
+        static::$httpClient = $httpClient;        
     }
 
     /**

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -124,10 +124,12 @@ class Reader implements ReaderImportInterface
      */
     public static function setHttpClient($httpClient)
     {
-        if (! $httpClient instanceof ZendHttp\Client || ! $httpClient instanceof ClientInterface) {
-            throw InvalidHttpClientException();
+        // var_dump($httpClient instanceof ZendHttp\Client);
+        // exit;
+        if (! $httpClient instanceof ZendHttp\Client && ! $httpClient instanceof ClientInterface) {
+            throw new InvalidHttpClientException();
         }
-        static::$httpClient = $httpClient;        
+        static::$httpClient = $httpClient;
     }
 
     /**
@@ -137,7 +139,7 @@ class Reader implements ReaderImportInterface
      */
     public static function getHttpClient()
     {
-        if (!static::$httpClient instanceof ZendHttp\Client || !static::$httpClient instanceof ClientInterface) {
+        if (!static::$httpClient instanceof ZendHttp\Client && !static::$httpClient instanceof ClientInterface) {
             static::$httpClient = new ZendHttp\Client();
         }
 

--- a/test/Reader/Http/Psr7ResponseDecoratorTest.php
+++ b/test/Reader/Http/Psr7ResponseDecoratorTest.php
@@ -16,6 +16,9 @@ use Zend\Feed\Reader\Http\HeaderAwareResponseInterface;
 use Zend\Feed\Reader\Http\ResponseInterface;
 use ZendTest\Feed\Reader\TestAsset\Psr7Stream;
 
+/**
+ * @covers \Zend\Feed\Reader\Http\Psr7ResponseDecorator
+ */
 class Psr7ResponseDecoratorTest extends TestCase
 {
     public function testDecoratorIsAFeedResponse()

--- a/test/Reader/Http/Psr7ResponseDecoratorTest.php
+++ b/test/Reader/Http/Psr7ResponseDecoratorTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Reader\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
+use Zend\Feed\Reader\Http\Psr7ResponseDecorator;
+use Zend\Feed\Reader\Http\HeaderAwareResponseInterface;
+use Zend\Feed\Reader\Http\ResponseInterface;
+use ZendTest\Feed\Reader\TestAsset\Psr7Stream;
+
+class Psr7ResponseDecoratorTest extends TestCase
+{
+    public function testDecoratorIsAFeedResponse()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertInstanceOf(ResponseInterface::class, $decorator);
+    }
+
+    public function testDecoratorIsAHeaderAwareResponse()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertInstanceOf(HeaderAwareResponseInterface::class, $decorator);
+    }
+
+    public function testDecoratorIsNotAPsr7Response()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertNotInstanceOf(Psr7ResponseInterface::class, $decorator);
+    }
+
+    public function testCanRetrieveDecoratedResponse()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame($originalResponse->reveal(), $decorator->getDecoratedResponse());
+    }
+
+    public function testProxiesToDecoratedResponseToRetrieveStatusCode()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $originalResponse->getStatusCode()->willReturn(301);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame(301, $decorator->getStatusCode());
+    }
+
+    public function testProxiesToDecoratedResponseToRetrieveBody()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $originalResponse->getBody()->willReturn('BODY');
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame('BODY', $decorator->getBody());
+    }
+
+    public function testCastsStreamToStringWhenReturningPsr7Body()
+    {
+        $stream = new Psr7Stream('BODY');
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $originalResponse->getBody()->willReturn($stream);
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame('BODY', $decorator->getBody());
+    }
+
+    public function testProxiesToDecoratedResponseToRetrieveHeaderLine()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $originalResponse->hasHeader('E-Tag')->willReturn(true);
+        $originalResponse->getHeaderLine('E-Tag')->willReturn('2015-11-17 12:32:00-06:00');
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame('2015-11-17 12:32:00-06:00', $decorator->getHeaderLine('E-Tag'));
+    }
+
+    public function testDecoratorReturnsDefaultValueWhenOriginalResponseDoesNotHaveHeader()
+    {
+        $originalResponse = $this->prophesize(Psr7ResponseInterface::class);
+        $originalResponse->hasHeader('E-Tag')->willReturn(false);
+        $originalResponse->getHeaderLine('E-Tag')->shouldNotBeCalled();
+        $decorator = new Psr7ResponseDecorator($originalResponse->reveal());
+        $this->assertSame('2015-11-17 12:32:00-06:00', $decorator->getHeaderLine('E-Tag', '2015-11-17 12:32:00-06:00'));
+    }
+}

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Reader\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Feed\Reader\Exception\InvalidArgumentException;
+use Zend\Feed\Reader\Http\Response;
+use ZendTest\Feed\Reader\TestAsset\Psr7Stream;
+
+class ResponseTest extends TestCase
+{
+    public function testConstructorOnlyRequiresStatusCode()
+    {
+        $response = new Response(200);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody());
+        $this->assertAttributeSame([], 'headers', $response);
+    }
+
+    public function testConstructorCanAcceptResponseBody()
+    {
+        $response = new Response(201, 'CREATED');
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('CREATED', $response->getBody());
+        $this->assertAttributeSame([], 'headers', $response);
+    }
+
+    public function testConstructorCanAcceptAStringCastableObjectForTheResponseBody()
+    {
+        $stream   = new Psr7Stream('BODY');
+        $response = new Response(200, $stream);
+        $this->assertEquals('BODY', $response->getBody());
+    }
+
+    public function testConstructorCanAcceptHeaders()
+    {
+        $response = new Response(204, '', [
+            'Location'         => 'http://example.org/foo',
+            'Content-Length'   => 1234,
+            'X-Content-Length' => 1234.56,
+        ]);
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody());
+        $this->assertEquals('http://example.org/foo', $response->getHeaderLine('Location'));
+        $this->assertEquals(1234, $response->getHeaderLine('Content-Length'));
+        $this->assertEquals(1234.56, $response->getHeaderLine('X-Content-Length'));
+    }
+
+    public function invalidStatusCodes()
+    {
+        foreach (range(-100, 99) as $statusCode) {
+            yield $statusCode => [$statusCode, 'between 100 and 599'];
+        }
+
+        foreach (range(600, 1000, 10) as $statusCode) {
+            yield $statusCode => [$statusCode, 'between 100 and 599'];
+        }
+
+        foreach ([100.1, 599.1] as $statusCode) {
+            yield $statusCode => [$statusCode, 'integer status code'];
+        }
+
+        $invalidTypes = [
+            'null'   => [null, 'numeric status code'],
+            'true'   => [true, 'numeric status code'],
+            'false'  => [false, 'numeric status code'],
+            'string' => [' 100 ', 'numeric status code'],
+            'array'  => [[200], 'numeric status code'],
+            'object' => [(object) [100], 'numeric status code'],
+        ];
+        foreach ($invalidTypes as $key => $value) {
+            yield $key => $value;
+        }
+    }
+
+    /**
+     * @dataProvider invalidStatusCodes
+     */
+    public function testConstructorRaisesExceptionForInvalidStatusCode($statusCode, $contains)
+    {
+        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        new Response($statusCode);
+    }
+
+    public function invalidBodies()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'array'      => [['BODY']],
+            'object'     => [(object) ['body' => 'BODY']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidBodies
+     */
+    public function testConstructorRaisesExceptionForInvalidBody($body)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+        new Response(200, $body);
+    }
+
+    public function invalidHeaders()
+    {
+        return [
+            'empty-name' => [
+                [ '' => 'value' ],
+                'non-empty, non-numeric',
+            ],
+            'zero-name' => [
+                [ 'value' ],
+                'non-empty, non-numeric',
+            ],
+            'int-name' => [
+                [ 1 => 'value' ],
+                'non-empty, non-numeric',
+            ],
+            'numeric-name' => [
+                [ '1.1' => 'value' ],
+                'non-empty, non-numeric',
+            ],
+            'null-value'       => [
+                [ 'X-Test' => null ],
+                'must be a string or numeric',
+            ],
+            'true-value'       => [
+                [ 'X-Test' => true ],
+                'must be a string or numeric',
+            ],
+            'false-value'      => [
+                [ 'X-Test' => false ],
+                'must be a string or numeric',
+            ],
+            'array-value'      => [
+                [ 'X-Test' => ['BODY'] ],
+                'must be a string or numeric',
+            ],
+            'object-value'     => [
+                [ 'X-Test' => (object) ['body' => 'BODY'] ],
+                'must be a string or numeric',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidHeaders
+     */
+    public function testConstructorRaisesExceptionForInvalidHeaderStructures($headers, $contains)
+    {
+        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        new Response(200, '', $headers);
+    }
+}

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -14,6 +14,9 @@ use Zend\Feed\Reader\Exception\InvalidArgumentException;
 use Zend\Feed\Reader\Http\Response;
 use ZendTest\Feed\Reader\TestAsset\Psr7Stream;
 
+/**
+ * @covers \Zend\Feed\Reader\Http\Response
+ */
 class ResponseTest extends TestCase
 {
     public function testConstructorOnlyRequiresStatusCode()

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -166,4 +166,10 @@ class ResponseTest extends TestCase
         $this->setExpectedException(InvalidArgumentException::class, $contains);
         new Response(200, '', $headers);
     }
+
+    public function testRetrievingHeaderLineWithDefaultValueReturnsDefaultValueWhenHeaderIsNotFound()
+    {
+        $response = new Response(200);
+        $this->assertSame('DEFAULT', $response->getHeaderLine('X-Not-Found', 'DEFAULT'));
+    }
 }

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -58,11 +58,11 @@ class ResponseTest extends TestCase
 
     public function invalidStatusCodes()
     {
-        foreach (range(-100, 99) as $statusCode) {
+        foreach ([-100, 0, 1, 99] as $statusCode) {
             yield $statusCode => [$statusCode, 'between 100 and 599'];
         }
 
-        foreach (range(600, 1000, 10) as $statusCode) {
+        foreach ([600, 700, 1000] as $statusCode) {
             yield $statusCode => [$statusCode, 'between 100 and 599'];
         }
 
@@ -135,23 +135,23 @@ class ResponseTest extends TestCase
                 [ '1.1' => 'value' ],
                 'non-empty, non-numeric',
             ],
-            'null-value'       => [
+            'null-value' => [
                 [ 'X-Test' => null ],
                 'must be a string or numeric',
             ],
-            'true-value'       => [
+            'true-value' => [
                 [ 'X-Test' => true ],
                 'must be a string or numeric',
             ],
-            'false-value'      => [
+            'false-value' => [
                 [ 'X-Test' => false ],
                 'must be a string or numeric',
             ],
-            'array-value'      => [
+            'array-value' => [
                 [ 'X-Test' => ['BODY'] ],
                 'must be a string or numeric',
             ],
-            'object-value'     => [
+            'object-value' => [
                 [ 'X-Test' => (object) ['body' => 'BODY'] ],
                 'must be a string or numeric',
             ],

--- a/test/Reader/Http/ZendHttpClientDecoratorTest.php
+++ b/test/Reader/Http/ZendHttpClientDecoratorTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Reader\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Zend\Feed\Reader\Exception\InvalidArgumentException;
+use Zend\Feed\Reader\Http\Response as FeedResponse;
+use Zend\Feed\Reader\Http\ZendHttpClientDecorator;
+use Zend\Http\Client;
+use Zend\Http\Headers;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+
+/**
+ * @covers \Zend\Feed\Reader\Http\ZendHttpClientDecorator
+ */
+class ZendHttpClientDecoratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->client = $this->prophesize(Client::class);
+    }
+
+    public function prepareDefaultClientInteractions($uri, ObjectProphecy $response)
+    {
+        $this->client->resetParameters()->shouldBeCalled();
+        $this->client->setMethod('GET')->shouldBeCalled();
+        $this->client->setHeaders(Argument::type(Headers::class))->shouldBeCalled();
+        $this->client->setUri($uri)->shouldBeCalled();
+        $this->client->send()->will(function () use ($response) {
+            return $response->reveal();
+        });
+    }
+
+    public function createMockHttpResponse($statusCode, $body, Headers $headers = null)
+    {
+        $response = $this->prophesize(HttpResponse::class);
+        $response->getStatusCode()->willReturn($statusCode);
+        $response->getBody()->willReturn($body);
+        $response->getHeaders()->willReturn($headers ?: new Headers());
+        return $response;
+    }
+
+    public function createMockHttpHeaders(array $headers)
+    {
+        $mock = $this->prophesize(Headers::class);
+        $mock->toArray()->willReturn($headers);
+        return $mock;
+    }
+
+    public function testDecoratorReturnsFeedResponse()
+    {
+        $headers = $this->createMockHttpHeaders(['Content-Type' => 'application/rss+xml']);
+        $httpResponse = $this->createMockHttpResponse(200, '', $headers->reveal());
+        $this->prepareDefaultClientInteractions('http://example.com', $httpResponse);
+
+        $client = new ZendHttpClientDecorator($this->client->reveal());
+        $response = $client->get('http://example.com');
+
+        $this->assertInstanceOf(FeedResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody());
+        $this->assertEquals('application/rss+xml', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testDecoratorInjectsProvidedHeadersIntoClientWhenSending()
+    {
+        $responseHeaders = $this->createMockHttpHeaders([
+            'Content-Type' => 'application/rss+xml',
+            'Content-Length' => 1234,
+            'X-Content-Length' => 1234.56,
+        ]);
+        $httpResponse = $this->createMockHttpResponse(200, '', $responseHeaders->reveal());
+        $this->prepareDefaultClientInteractions('http://example.com', $httpResponse);
+
+        $requestHeaders = $this->prophesize(Headers::class);
+        $requestHeaders->addHeaderLine('Accept', 'application/rss+xml')->shouldBeCalled();
+        $request = $this->prophesize(HttpRequest::class);
+        $request->getHeaders()->willReturn($requestHeaders->reveal());
+        $this->client->getRequest()->willReturn($request->reveal());
+
+        $client = new ZendHttpClientDecorator($this->client->reveal());
+        $response = $client->get('http://example.com', ['Accept' => [ 'application/rss+xml' ]]);
+
+        $this->assertInstanceOf(FeedResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('', $response->getBody());
+        $this->assertEquals('application/rss+xml', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals(1234, $response->getHeaderLine('Content-Length'));
+        $this->assertEquals(1234.56, $response->getHeaderLine('X-Content-Length'));
+    }
+
+    public function invalidHeaders()
+    {
+        $basicTests = [
+            'zero-name' => [
+                [[ 'value' ]],
+                'Header names',
+            ],
+            'int-name' => [
+                [1 => [ 'value' ]],
+                'Header names',
+            ],
+            'numeric-name' => [
+                ['1.1' => [ 'value' ]],
+                'Header names',
+            ],
+            'empty-name' => [
+                ['' => [ 'value' ]],
+                'Header names',
+            ],
+            'null-value' => [
+                ['X-Test' => null],
+                'Header values',
+            ],
+            'true-value' => [
+                ['X-Test' => true],
+                'Header values',
+            ],
+            'false-value' => [
+                ['X-Test' => false],
+                'Header values',
+            ],
+            'zero-value' => [
+                ['X-Test' => 0],
+                'Header values',
+            ],
+            'int-value' => [
+                ['X-Test' => 1],
+                'Header values',
+            ],
+            'zero-float-value' => [
+                ['X-Test' => 0.0],
+                'Header values',
+            ],
+            'float-value' => [
+                ['X-Test' => 1.1],
+                'Header values',
+            ],
+            'string-value' => [
+                ['X-Test' => 'value'],
+                'Header values',
+            ],
+            'object-value' => [
+                ['X-Test' => (object) [ 'value' ]],
+                'Header values',
+            ],
+        ];
+
+        foreach ($basicTests as $key => $arguments) {
+            yield $key => $arguments;
+        }
+
+        $invalidIndividualValues = [
+            'null-individual-value'   => null,
+            'true-individual-value'   => true,
+            'false-individual-value'  => false,
+            'array-individual-value'  => ['string'],
+            'object-individual-value' => (object) ['string'],
+        ];
+
+        foreach ($invalidIndividualValues as $key => $value) {
+            yield $key => [['X-Test' => [ $value ]], 'strings or numbers'];
+        }
+    }
+
+    /**
+     * @dataProvider invalidHeaders
+     */
+    public function testDecoratorRaisesExceptionForInvalidHeaders($headers, $contains)
+    {
+        $httpResponse = $this->createMockHttpResponse(200, '');
+        $this->client->resetParameters()->shouldBeCalled();
+        $this->client->setMethod('GET')->shouldBeCalled();
+        $this->client->setHeaders(Argument::type(Headers::class))->shouldBeCalled();
+        $this->client->setUri('http://example.com')->shouldBeCalled();
+
+        $requestHeaders = $this->prophesize(Headers::class);
+        $request = $this->prophesize(HttpRequest::class);
+        $request->getHeaders()->willReturn($requestHeaders->reveal());
+        $this->client->getRequest()->willReturn($request->reveal());
+
+        $client = new ZendHttpClientDecorator($this->client->reveal());
+
+        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        $client->get('http://example.com', $headers);
+    }
+}

--- a/test/Reader/Http/ZendHttpClientDecoratorTest.php
+++ b/test/Reader/Http/ZendHttpClientDecoratorTest.php
@@ -57,6 +57,13 @@ class ZendHttpClientDecoratorTest extends TestCase
         return $mock;
     }
 
+    public function testProvidesAccessToDecoratedClient()
+    {
+        $client = $this->prophesize(Client::class)->reveal();
+        $decorator = new ZendHttpClientDecorator($client);
+        $this->assertSame($client, $decorator->getDecoratedClient());
+    }
+
     public function testDecoratorReturnsFeedResponse()
     {
         $headers = $this->createMockHttpHeaders(['Content-Type' => 'application/rss+xml']);

--- a/test/Reader/ReaderTest.php
+++ b/test/Reader/ReaderTest.php
@@ -309,6 +309,28 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString($string);
     }
 
+    public function testSetHttpFeedClient()
+    {
+        $client = $this->getMock('Zend\Feed\Reader\Http\ClientInterface');
+        Reader\Reader::setHttpClient($client);
+        $this->assertEquals($client, Reader\Reader::getHttpClient());
+    }
+
+    public function testSetHttpClient()
+    {
+        $client = new HttpClient();
+        Reader\Reader::setHttpClient($client);
+        $this->assertEquals($client, Reader\Reader::getHttpClient());
+    }
+
+    /**
+     * @expectedException Zend\Feed\Reader\Exception\InvalidHttpClientException
+     */
+    public function testSetHttpClientThrowsException()
+    {
+        Reader\Reader::setHttpClient(new \stdClass);
+    }
+
     protected function _getTempDirectory()
     {
         $tmpdir = [];

--- a/test/Reader/ReaderTest.php
+++ b/test/Reader/ReaderTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Feed\Reader;
 
+use stdClass;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as TestAdapter;
 use Zend\Http\Response as HttpResponse;
@@ -326,13 +327,6 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($client, Reader\Reader::getHttpClient());
     }
 
-    public function testSetHttpClient()
-    {
-        $client = $this->prophesize(ClientInterface::class)->reveal();
-        Reader\Reader::setHttpClient($client);
-        $this->assertSame($client, Reader\Reader::getHttpClient());
-    }
-
     public function testSetHttpClientWillDecorateAZendHttpClientInstance()
     {
         $client = new HttpClient();
@@ -342,12 +336,10 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($client, 'client', $cached);
     }
 
-    /**
-     * @expectedException Zend\Feed\Reader\Exception\InvalidHttpClientException
-     */
     public function testSetHttpClientThrowsException()
     {
-        Reader\Reader::setHttpClient(new \stdClass);
+        $this->setExpectedException(Reader\Exception\InvalidHttpClientException::class);
+        Reader\Reader::setHttpClient(new stdClass);
     }
 
     protected function _getTempDirectory()

--- a/test/Reader/ReaderTest.php
+++ b/test/Reader/ReaderTest.php
@@ -13,6 +13,7 @@ use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\Test as TestAdapter;
 use Zend\Http\Response as HttpResponse;
 use Zend\Feed\Reader;
+use Zend\Feed\Reader\Http\ClientInterface;
 
 /**
 * @group Zend_Feed
@@ -42,7 +43,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss20()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss20.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss20.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_20, $type);
     }
@@ -50,7 +52,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss094()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss094.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss094.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_094, $type);
     }
@@ -58,7 +61,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss093()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss093.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss093.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_093, $type);
     }
@@ -66,7 +70,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss092()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss092.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss092.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_092, $type);
     }
@@ -74,7 +79,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss091()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss091.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss091.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_091, $type);
     }
@@ -82,7 +88,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss10()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss10.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss10.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_10, $type);
     }
@@ -90,7 +97,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsRss090()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/rss090.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/rss090.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_RSS_090, $type);
     }
@@ -98,7 +106,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsAtom10()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/atom10.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/atom10.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_ATOM_10, $type);
     }
@@ -106,7 +115,8 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     public function testDetectsFeedIsAtom03()
     {
         $feed = Reader\Reader::importString(
-            file_get_contents($this->feedSamplePath.'/Reader/atom03.xml'));
+            file_get_contents($this->feedSamplePath.'/Reader/atom03.xml')
+        );
         $type = Reader\Reader::detectType($feed);
         $this->assertEquals(Reader\Reader::TYPE_ATOM_03, $type);
     }
@@ -318,9 +328,18 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
     public function testSetHttpClient()
     {
+        $client = $this->prophesize(ClientInterface::class)->reveal();
+        Reader\Reader::setHttpClient($client);
+        $this->assertSame($client, Reader\Reader::getHttpClient());
+    }
+
+    public function testSetHttpClientWillDecorateAZendHttpClientInstance()
+    {
         $client = new HttpClient();
         Reader\Reader::setHttpClient($client);
-        $this->assertEquals($client, Reader\Reader::getHttpClient());
+        $cached = Reader\Reader::getHttpClient();
+        $this->assertInstanceOf(ClientInterface::class, $cached);
+        $this->assertAttributeSame($client, 'client', $cached);
     }
 
     /**

--- a/test/Reader/TestAsset/Psr7Stream.php
+++ b/test/Reader/TestAsset/Psr7Stream.php
@@ -9,9 +9,13 @@
 
 namespace ZendTest\Feed\Reader\TestAsset;
 
-use Psr\Http\Message\StreamInterface;
-
-class Psr7Stream implements StreamInterface
+/**
+ * This class may be used as a dummy for testing the return value from a
+ * PSR-7 message's getBody() method. It does not implement the StreamInterface,
+ * as PHP prior to version 7 does not do any return typehinting, making strict
+ * adherence unnecessary.
+ */
+class Psr7Stream
 {
     private $streamValue;
 
@@ -23,61 +27,5 @@ class Psr7Stream implements StreamInterface
     public function __toString()
     {
         return (string) $this->streamValue;
-    }
-
-    public function close()
-    {
-    }
-
-    public function detach()
-    {
-    }
-
-    public function getSize()
-    {
-    }
-
-    public function tell()
-    {
-    }
-
-    public function eof()
-    {
-    }
-
-    public function isSeekable()
-    {
-    }
-
-    public function seek($offset, $whence = SEEK_SET)
-    {
-    }
-
-    public function rewind()
-    {
-    }
-
-    public function isWritable()
-    {
-    }
-
-    public function write($string)
-    {
-    }
-
-    public function isReadable()
-    {
-    }
-
-    public function read($length)
-    {
-    }
-
-    public function getContents()
-    {
-    }
-
-    public function getMetadata($key = null)
-    {
     }
 }

--- a/test/Reader/TestAsset/Psr7Stream.php
+++ b/test/Reader/TestAsset/Psr7Stream.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Reader\TestAsset;
+
+use Psr\Http\Message\StreamInterface;
+
+class Psr7Stream implements StreamInterface
+{
+    private $streamValue;
+
+    public function __construct($streamValue)
+    {
+        $this->streamValue = $streamValue;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->streamValue;
+    }
+
+    public function close()
+    {
+    }
+
+    public function detach()
+    {
+    }
+
+    public function getSize()
+    {
+    }
+
+    public function tell()
+    {
+    }
+
+    public function eof()
+    {
+    }
+
+    public function isSeekable()
+    {
+    }
+
+    public function seek($offset, $whence = SEEK_SET)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function isWritable()
+    {
+    }
+
+    public function write($string)
+    {
+    }
+
+    public function isReadable()
+    {
+    }
+
+    public function read($length)
+    {
+    }
+
+    public function getContents()
+    {
+    }
+
+    public function getMetadata($key = null)
+    {
+    }
+}


### PR DESCRIPTION
This patch extends from and builds on #8 to allow for any `Zend\Feed\Reader\Http\ClientInterface` implementations to work for `Zend\Feed\Reader\Reader` operations that need an HTTP client. To make this happen, it does the following:
- Adds `Zend\Feed\Reader\Http\HeaderAwareClientInterface`, which defines the `get()` method with an additional, optional argument, `array $headers = []`. This allows passing the `If-*` headers used for testing HTTP caching.
- Adds `Zend\Feed\Reader\Http\HeaderAwareResponseInterface`, which extends the `ResponseInterface` to add a `getHeader($name, $default = null)` method; this, too, is used in situations where using HTTP cache headers.
- Adds `Zend\Feed\Reader\Http\Response`, an implementation of `HeaderAwareResponseInterface`. Its constructor accepts the status code, body, and optionally headers and validates and normalizes them.
- Adds `Zend\Feed\Reader\Http\ZendHttpClientDecorator`, an implementation of `ClientInterface` that decorates a zend-http client instance, and ensures a properly seeded `HeaderAwareResponseInterface` instance is returned.
- Updates `Zend\Feed\Reader\Reader::setHttpClient()` to decorate instances of `Zend\Http\Client` using the `ZendHttpClientDecorator`.
- Updates `Zend\Feed\Reader\Reader::getHttpClient()` to lazy-load a zend-http client and decorate it using `ZendHttpClientDecorator` if no instance is currently attached.
- Updates `Zend\Feed\Reader\Reader::import()` to use a `ClientInterface` instance. Internally, it also checks to see if that instance implements `HeaderAwareClientInterface` in order to provide headers when fetching a feed, and checks the returned response against `HeaderAwareResponseInterface` in order to fetch headers when HTTP cache checks are necessary.
- Updates `Zend\Feed\Reader\Reader::findFeedLinks()` to use only methods defined in `ClientInterface`.

The only test changes necessary were:
- Updating `testSetHttpClient()` to use a mock `ClientInterface` and test for identity.
- Adding the method `testSetHttpClientWillDecorateAZendHttpClientInstance()` to ensure that passing a zend-http client to `setHttpClient()` decorates it with `ZendHttpClientDecorator`.

The latter test ensures that the changes are backwards compatible.

This feature remains _mostly_ backwards compatible with previous versions, but should target the next minor release (2.6.0).

The one potential BC break is that `Reader::getHttpClient()` now properly returns a `Zend\Feed\Reader\Http\ClientInterface` instance. This was possible previously if a `ClientInterface` was injected, but the method signature had not been updated.

For users who relied on the method returning a `Zend\Http\Client` instance, `Zend\Feed\Reader\Http\ZendHttpClientDecorator` exposes a `getDecoratedClient()` method for retrieving the original instance.
