### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-escaper": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "~2.5",
+        "zendframework/zend-http": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-db": "~2.5",
         "zendframework/zend-cache": "~2.5",
-        "zendframework/zend-http": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0",


### PR DESCRIPTION
zend-http is mandatory to use basic reader

whithout zend-http...

$channel = \Zend\Feed\Reader\Reader::import($input->getArgument('link'));

...throws

 php.CRITICAL: Fatal error: Class 'AppBundle\Command\Zend\Feed\Reader\Reader' not found
