### PR TITLE
Made zend-feed forwards compatible with zend-stdlib and zend-servicemanager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,24 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -38,6 +49,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-cache zendframework/zend-db zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,16 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-escaper": "~2.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-escaper": "^2.5",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-db": "~2.5",
-        "zendframework/zend-cache": "dev-develop as 2.6.0",
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-db": "^2.5",
+        "zendframework/zend-cache": "^2.5",
+        "zendframework/zend-http": "^2.5",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-validator": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0",
         "psr/http-message": "^1.0"
@@ -32,14 +33,14 @@
         "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
         "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
-        "zendframework/zend-validator": "Zend\\Validator component, for validating feeds and Atom entries in the Writer subcomponent"
+        "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries ehen using the Writer subcomponent"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev",
-            "dev-develop": "3.0-dev"
+            "dev-develop": "2.7-dev"
         }
     },
     "autoload-dev": {

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -10,6 +10,8 @@
 namespace Zend\Feed\Reader;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for feed reader extensions based on the
@@ -21,28 +23,98 @@ use Zend\ServiceManager\AbstractPluginManager;
 class ExtensionPluginManager extends AbstractPluginManager
 {
     /**
-     * Default set of extension classes
+     * Aliases for default set of extension classes
      *
      * @var array
      */
-    protected $invokables = [
-        'atomentry'            => 'Zend\Feed\Reader\Extension\Atom\Entry',
-        'atomfeed'             => 'Zend\Feed\Reader\Extension\Atom\Feed',
-        'contententry'         => 'Zend\Feed\Reader\Extension\Content\Entry',
-        'creativecommonsentry' => 'Zend\Feed\Reader\Extension\CreativeCommons\Entry',
-        'creativecommonsfeed'  => 'Zend\Feed\Reader\Extension\CreativeCommons\Feed',
-        'dublincoreentry'      => 'Zend\Feed\Reader\Extension\DublinCore\Entry',
-        'dublincorefeed'       => 'Zend\Feed\Reader\Extension\DublinCore\Feed',
-        'podcastentry'         => 'Zend\Feed\Reader\Extension\Podcast\Entry',
-        'podcastfeed'          => 'Zend\Feed\Reader\Extension\Podcast\Feed',
-        'slashentry'           => 'Zend\Feed\Reader\Extension\Slash\Entry',
-        'syndicationfeed'      => 'Zend\Feed\Reader\Extension\Syndication\Feed',
-        'threadentry'          => 'Zend\Feed\Reader\Extension\Thread\Entry',
-        'wellformedwebentry'   => 'Zend\Feed\Reader\Extension\WellFormedWeb\Entry',
+    protected $aliases = [
+        'atomentry'            => Extension\Atom\Entry::class,
+        'atomEntry'            => Extension\Atom\Entry::class,
+        'AtomEntry'            => Extension\Atom\Entry::class,
+        'atomfeed'             => Extension\Atom\Feed::class,
+        'atomFeed'             => Extension\Atom\Feed::class,
+        'AtomFeed'             => Extension\Atom\Feed::class,
+        'contententry'         => Extension\Content\Entry::class,
+        'contentEntry'         => Extension\Content\Entry::class,
+        'ContentEntry'         => Extension\Content\Entry::class,
+        'creativecommonsentry' => Extension\CreativeCommons\Entry::class,
+        'creativeCommonsEntry' => Extension\CreativeCommons\Entry::class,
+        'CreativeCommonsEntry' => Extension\CreativeCommons\Entry::class,
+        'creativecommonsfeed'  => Extension\CreativeCommons\Feed::class,
+        'creativeCommonsFeed'  => Extension\CreativeCommons\Feed::class,
+        'CreativeCommonsFeed'  => Extension\CreativeCommons\Feed::class,
+        'dublincoreentry'      => Extension\DublinCore\Entry::class,
+        'dublinCoreEntry'      => Extension\DublinCore\Entry::class,
+        'DublinCoreEntry'      => Extension\DublinCore\Entry::class,
+        'dublincorefeed'       => Extension\DublinCore\Feed::class,
+        'dublinCoreFeed'       => Extension\DublinCore\Feed::class,
+        'DublinCoreFeed'       => Extension\DublinCore\Feed::class,
+        'podcastentry'         => Extension\Podcast\Entry::class,
+        'podcastEntry'         => Extension\Podcast\Entry::class,
+        'PodcastEntry'         => Extension\Podcast\Entry::class,
+        'podcastfeed'          => Extension\Podcast\Feed::class,
+        'podcastFeed'          => Extension\Podcast\Feed::class,
+        'PodcastFeed'          => Extension\Podcast\Feed::class,
+        'slashentry'           => Extension\Slash\Entry::class,
+        'slashEntry'           => Extension\Slash\Entry::class,
+        'SlashEntry'           => Extension\Slash\Entry::class,
+        'syndicationfeed'      => Extension\Syndication\Feed::class,
+        'syndicationFeed'      => Extension\Syndication\Feed::class,
+        'SyndicationFeed'      => Extension\Syndication\Feed::class,
+        'threadentry'          => Extension\Thread\Entry::class,
+        'threadEntry'          => Extension\Thread\Entry::class,
+        'ThreadEntry'          => Extension\Thread\Entry::class,
+        'wellformedwebentry'   => Extension\WellFormedWeb\Entry::class,
+        'wellFormedWebEntry'   => Extension\WellFormedWeb\Entry::class,
+        'WellFormedWebEntry'   => Extension\WellFormedWeb\Entry::class,
     ];
 
     /**
-     * Do not share instances
+     * Factories for default set of extension classes
+     *
+     * @var array
+     */
+    protected $factories = [
+        Extension\Atom\Entry::class            => InvokableFactory::class,
+        Extension\Atom\Feed::class             => InvokableFactory::class,
+        Extension\Content\Entry::class         => InvokableFactory::class,
+        Extension\CreativeCommons\Entry::class => InvokableFactory::class,
+        Extension\CreativeCommons\Feed::class  => InvokableFactory::class,
+        Extension\DublinCore\Entry::class      => InvokableFactory::class,
+        Extension\DublinCore\Feed::class       => InvokableFactory::class,
+        Extension\Podcast\Entry::class         => InvokableFactory::class,
+        Extension\Podcast\Feed::class          => InvokableFactory::class,
+        Extension\Slash\Entry::class           => InvokableFactory::class,
+        Extension\Syndication\Feed::class      => InvokableFactory::class,
+        Extension\Thread\Entry::class          => InvokableFactory::class,
+        Extension\WellFormedWeb\Entry::class   => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendfeedreaderextensionatomentry'            => InvokableFactory::class,
+        'zendfeedreaderextensionatomfeed'             => InvokableFactory::class,
+        'zendfeedreaderextensioncontententry'         => InvokableFactory::class,
+        'zendfeedreaderextensioncreativecommonsentry' => InvokableFactory::class,
+        'zendfeedreaderextensioncreativecommonsfeed'  => InvokableFactory::class,
+        'zendfeedreaderextensiondublincoreentry'      => InvokableFactory::class,
+        'zendfeedreaderextensiondublincorefeed'       => InvokableFactory::class,
+        'zendfeedreaderextensionpodcastentry'         => InvokableFactory::class,
+        'zendfeedreaderextensionpodcastfeed'          => InvokableFactory::class,
+        'zendfeedreaderextensionslashentry'           => InvokableFactory::class,
+        'zendfeedreaderextensionsyndicationfeed'      => InvokableFactory::class,
+        'zendfeedreaderextensionthreadentry'          => InvokableFactory::class,
+        'zendfeedreaderextensionwellformedwebentry'   => InvokableFactory::class,
+    ];
+
+    /**
+     * Do not share instances (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Do not share instances (v3)
      *
      * @var bool
      */
@@ -53,25 +125,47 @@ class ExtensionPluginManager extends AbstractPluginManager
      *
      * Checks that the extension loaded is of a valid type.
      *
-     * @param  mixed $instance
+     * @param  mixed $plugin
      * @return void
      * @throws Exception\InvalidArgumentException if invalid
      */
-    public function validate($instance)
+    public function validate($plugin)
     {
-        if ($instance instanceof Extension\AbstractEntry
-            || $instance instanceof Extension\AbstractFeed
+        if ($plugin instanceof Extension\AbstractEntry
+            || $plugin instanceof Extension\AbstractFeed
         ) {
             // we're okay
             return;
         }
 
-        throw new Exception\InvalidArgumentException(sprintf(
+        throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
             . 'or %s\Extension\AbstractEntry',
-            (is_object($instance) ? get_class($instance) : gettype($instance)),
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
             __NAMESPACE__,
             __NAMESPACE__
         ));
+    }
+
+    /**
+     * Validate the plugin (v2)
+     *
+     * @param  mixed $plugin
+     * @return void
+     * @throws Exception\InvalidArgumentException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
+                . 'or %s\Extension\AbstractEntry',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__,
+                __NAMESPACE__
+            ));
+        }
     }
 }

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -10,6 +10,8 @@
 namespace Zend\Feed\Writer;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for feed writer extensions
@@ -19,62 +21,149 @@ use Zend\ServiceManager\AbstractPluginManager;
 class ExtensionPluginManager extends AbstractPluginManager
 {
     /**
-     * Default set of extension classes
+     * Aliases for default set of extension classes
      *
      * @var array
      */
-    protected $invokables = [
-        'atomrendererfeed'           => 'Zend\Feed\Writer\Extension\Atom\Renderer\Feed',
-        'contentrendererentry'       => 'Zend\Feed\Writer\Extension\Content\Renderer\Entry',
-        'dublincorerendererentry'    => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry',
-        'dublincorerendererfeed'     => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed',
-        'itunesentry'                => 'Zend\Feed\Writer\Extension\ITunes\Entry',
-        'itunesfeed'                 => 'Zend\Feed\Writer\Extension\ITunes\Feed',
-        'itunesrendererentry'        => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Entry',
-        'itunesrendererfeed'         => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Feed',
-        'slashrendererentry'         => 'Zend\Feed\Writer\Extension\Slash\Renderer\Entry',
-        'threadingrendererentry'     => 'Zend\Feed\Writer\Extension\Threading\Renderer\Entry',
-        'wellformedwebrendererentry' => 'Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry',
+    protected $aliases = [
+        'atomrendererfeed'           => Extension\Atom\Renderer\Feed::class,
+        'atomRendererFeed'           => Extension\Atom\Renderer\Feed::class,
+        'AtomRendererFeed'           => Extension\Atom\Renderer\Feed::class,
+        'contentrendererentry'       => Extension\Content\Renderer\Entry::class,
+        'contentRendererEntry'       => Extension\Content\Renderer\Entry::class,
+        'ContentRendererEntry'       => Extension\Content\Renderer\Entry::class,
+        'dublincorerendererentry'    => Extension\DublinCore\Renderer\Entry::class,
+        'dublinCoreRendererEntry'    => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCoreRendererEntry'    => Extension\DublinCore\Renderer\Entry::class,
+        'dublincorerendererfeed'     => Extension\DublinCore\Renderer\Feed::class,
+        'dublinCoreRendererFeed'     => Extension\DublinCore\Renderer\Feed::class,
+        'DublinCoreRendererFeed'     => Extension\DublinCore\Renderer\Feed::class,
+        'itunesentry'                => Extension\ITunes\Entry::class,
+        'itunesEntry'                => Extension\ITunes\Entry::class,
+        'iTunesEntry'                => Extension\ITunes\Entry::class,
+        'ItunesEntry'                => Extension\ITunes\Entry::class,
+        'itunesfeed'                 => Extension\ITunes\Feed::class,
+        'itunesFeed'                 => Extension\ITunes\Feed::class,
+        'iTunesFeed'                 => Extension\ITunes\Feed::class,
+        'ItunesFeed'                 => Extension\ITunes\Feed::class,
+        'itunesrendererentry'        => Extension\ITunes\Renderer\Entry::class,
+        'itunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
+        'iTunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
+        'ItunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
+        'itunesrendererfeed'         => Extension\ITunes\Renderer\Feed::class,
+        'itunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
+        'iTunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
+        'ItunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
+        'slashrendererentry'         => Extension\Slash\Renderer\Entry::class,
+        'slashRendererEntry'         => Extension\Slash\Renderer\Entry::class,
+        'SlashRendererEntry'         => Extension\Slash\Renderer\Entry::class,
+        'threadingrendererentry'     => Extension\Threading\Renderer\Entry::class,
+        'threadingRendererEntry'     => Extension\Threading\Renderer\Entry::class,
+        'ThreadingRendererEntry'     => Extension\Threading\Renderer\Entry::class,
+        'wellformedwebrendererentry' => Extension\WellFormedWeb\Renderer\Entry::class,
+        'wellFormedWebRendererEntry' => Extension\WellFormedWeb\Renderer\Entry::class,
+        'WellFormedWebRendererEntry' => Extension\WellFormedWeb\Renderer\Entry::class,
     ];
 
     /**
-     * Do not share instances
+     * Factories for default set of extension classes
+     *
+     * @var array
+     */
+    protected $factories = [
+        Extension\Atom\Renderer\Feed::class           => InvokableFactory::class,
+        Extension\Content\Renderer\Entry::class       => InvokableFactory::class,
+        Extension\DublinCore\Renderer\Entry::class    => InvokableFactory::class,
+        Extension\DublinCore\Renderer\Feed::class     => InvokableFactory::class,
+        Extension\ITunes\Entry::class                 => InvokableFactory::class,
+        Extension\ITunes\Feed::class                  => InvokableFactory::class,
+        Extension\ITunes\Renderer\Entry::class        => InvokableFactory::class,
+        Extension\ITunes\Renderer\Feed::class         => InvokableFactory::class,
+        Extension\Slash\Renderer\Entry::class         => InvokableFactory::class,
+        Extension\Threading\Renderer\Entry::class     => InvokableFactory::class,
+        Extension\WellFormedWeb\Renderer\Entry::class => InvokableFactory::class,
+        // Legacy (v2) due to alias resolution; canonical form of resolved
+        // alias is used to look up the factory, while the non-normalized
+        // resolved alias is used as the requested name passed to the factory.
+        'zendfeedwriterextensionatomrendererfeed'           => InvokableFactory::class,
+        'zendfeedwriterextensioncontentrendererentry'       => InvokableFactory::class,
+        'zendfeedwriterextensiondublincorerendererentry'    => InvokableFactory::class,
+        'zendfeedwriterextensiondublincorerendererfeed'     => InvokableFactory::class,
+        'zendfeedwriterextensionitunesentry'                => InvokableFactory::class,
+        'zendfeedwriterextensionitunesfeed'                 => InvokableFactory::class,
+        'zendfeedwriterextensionitunesrendererentry'        => InvokableFactory::class,
+        'zendfeedwriterextensionitunesrendererfeed'         => InvokableFactory::class,
+        'zendfeedwriterextensionslashrendererentry'         => InvokableFactory::class,
+        'zendfeedwriterextensionthreadingrendererentry'     => InvokableFactory::class,
+        'zendfeedwriterextensionwellformedwebrendererentry' => InvokableFactory::class,
+    ];
+
+    /**
+     * Do not share instances (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Do not share instances (v3)
      *
      * @var bool
      */
     protected $sharedByDefault = false;
 
     /**
-     * Validate the plugin
+     * Validate the plugin (v3)
      *
      * Checks that the extension loaded is of a valid type.
      *
-     * @param  mixed $instance
+     * @param  mixed $plugin
      * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @throws InvalidServiceException if invalid
      */
-    public function validate($instance)
+    public function validate($plugin)
     {
-        if ($instance instanceof Extension\AbstractRenderer) {
+        if ($plugin instanceof Extension\AbstractRenderer) {
             // we're okay
             return;
         }
 
-        if ('Feed' == substr(get_class($instance), -4)) {
+        if ('Feed' == substr(get_class($plugin), -4)) {
             // we're okay
             return;
         }
 
-        if ('Entry' == substr(get_class($instance), -5)) {
+        if ('Entry' == substr(get_class($plugin), -5)) {
             // we're okay
             return;
         }
 
-        throw new Exception\InvalidArgumentException(sprintf(
+        throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s\Extension\RendererInterface '
             . 'or the classname must end in "Feed" or "Entry"',
-            (is_object($instance) ? get_class($instance) : gettype($instance)),
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
             __NAMESPACE__
         ));
+    }
+
+    /**
+     * Validate plugin (v2)
+     *
+     * @param mixed $plugin
+     * @return void
+     * @throws Exception\InvalidArgumentException when invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must implement %s\Extension\RendererInterface '
+                . 'or the classname must end in "Feed" or "Entry"',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                __NAMESPACE__
+            ));
+        }
     }
 }

--- a/test/PubSubHubbub/Model/SubscriptionTest.php
+++ b/test/PubSubHubbub/Model/SubscriptionTest.php
@@ -26,6 +26,13 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllOperations()
     {
+        if (! class_exists(DbAdapter::class)) {
+            $this->markTestSkipped(
+                'Skipping tests against zend-db functionality until that '
+                . 'component is forwards-compatible with zend-servicemanager v3'
+            );
+        }
+
         $adapter = $this->initDb();
         $table = new TableGateway('subscription', $adapter);
 
@@ -40,10 +47,17 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($subscription->hasSubscription($id));
         $dataSubscription = $subscription->getSubscription($id);
         $this->assertInternalType('array', $dataSubscription);
-        $keys = ['id', 'topic_url', 'hub_url',
-                      'created_time', 'lease_seconds',
-                      'verify_token', 'secret',
-                      'expiration_time', 'subscription_state'];
+        $keys = [
+            'id',
+            'topic_url',
+            'hub_url',
+            'created_time',
+            'lease_seconds',
+            'verify_token',
+            'secret',
+            'expiration_time',
+            'subscription_state'
+        ];
 
         $this->assertSame($keys, array_keys($dataSubscription));
         $this->assertFalse($subscription->setSubscription(['id' => $id]));
@@ -59,6 +73,13 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testCurrentTimeSetterAndGetter()
     {
+        if (! class_exists(DbAdapter::class)) {
+            $this->markTestSkipped(
+                'Skipping tests against zend-db functionality until that '
+                . 'component is forwards-compatible with zend-servicemanager v3'
+            );
+        }
+
         $now = new DateTime();
         $subscription = new Subscription(new TableGateway('subscription', $this->initDb()));
         $subscription->setNow($now);
@@ -81,16 +102,16 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
     protected function createTable(DbAdapter $db)
     {
         $sql = "CREATE TABLE subscription ("
-             .      "id varchar(32) PRIMARY KEY NOT NULL DEFAULT '', "
-             .      "topic_url varchar(255) DEFAULT NULL, "
-             .      "hub_url varchar(255) DEFAULT NULL, "
-             .      "created_time datetime DEFAULT NULL, "
-             .      "lease_seconds bigint(20) DEFAULT NULL, "
-             .      "verify_token varchar(255) DEFAULT NULL, "
-             .      "secret varchar(255) DEFAULT NULL, "
-             .      "expiration_time datetime DEFAULT NULL, "
-             .      "subscription_state varchar(12) DEFAULT NULL"
-             . ");";
+            . "id varchar(32) PRIMARY KEY NOT NULL DEFAULT '', "
+            . "topic_url varchar(255) DEFAULT NULL, "
+            . "hub_url varchar(255) DEFAULT NULL, "
+            . "created_time datetime DEFAULT NULL, "
+            . "lease_seconds bigint(20) DEFAULT NULL, "
+            . "verify_token varchar(255) DEFAULT NULL, "
+            . "secret varchar(255) DEFAULT NULL, "
+            . "expiration_time datetime DEFAULT NULL, "
+            . "subscription_state varchar(12) DEFAULT NULL"
+            . ");";
 
         $db->query($sql)->execute();
     }

--- a/test/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/test/PubSubHubbub/Subscriber/CallbackTest.php
@@ -37,6 +37,13 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'Skipping tests against zend-db functionality until that '
+                . 'component is forwards-compatible with zend-servicemanager v3'
+            );
+        }
+
         $this->_callback = new CallbackSubscriber;
 
         $this->_adapter      = $this->_getCleanMock(
@@ -140,9 +147,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $mockReturnValue->expects($this->any())
             ->method('getArrayCopy')
             ->will($this->returnValue([
-                                           'verify_token' => hash('sha256',
-                                                                  'cba')
-                                      ]));
+                'verify_token' => hash('sha256', 'cba')
+            ]));
 
         $this->_tableGateway->expects($this->any())
             ->method('select')
@@ -194,9 +200,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $mockReturnValue->expects($this->any())
             ->method('getArrayCopy')
             ->will($this->returnValue([
-                                           'verify_token' => hash('sha256',
-                                                                  'cba')
-                                      ]));
+                'verify_token' => hash('sha256', 'cba')
+            ]));
 
         $this->_get['hub_mode'] = 'unsubscribe';
         $this->_tableGateway->expects($this->any())
@@ -312,15 +317,16 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->_tableGateway->expects($this->once())
             ->method('update')
             ->with(
-            $this->equalTo(['id'                => 'verifytokenkey',
-                                 'verify_token'      => hash('sha256', 'cba'),
-                                 'created_time'      => $t->getTimestamp(),
-                                 'lease_seconds'     => 1234567,
-                                 'subscription_state'=> 'verified',
-                                 'expiration_time'   => $t->add(new DateInterval('PT1234567S'))
-                                     ->format('Y-m-d H:i:s')]),
-            $this->equalTo(['id' => 'verifytokenkey'])
-        );
+                $this->equalTo([
+                    'id'                => 'verifytokenkey',
+                    'verify_token'      => hash('sha256', 'cba'),
+                    'created_time'      => $t->getTimestamp(),
+                    'lease_seconds'     => 1234567,
+                    'subscription_state'=> 'verified',
+                    'expiration_time'   => $t->add(new DateInterval('PT1234567S'))->format('Y-m-d H:i:s')
+                ]),
+                $this->equalTo(['id' => 'verifytokenkey'])
+            );
 
         $this->_callback->handle($this->_get);
         $this->assertEquals('abc', $this->_callback->getHttpResponse()->getContent());
@@ -360,7 +366,8 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testRespondsToInvalidFeedUpdateNotPostWith404Response()
-    { // yes, this example makes no sense for GET - I know!!!
+    {
+        // yes, this example makes no sense for GET - I know!!!
         $_SERVER['REQUEST_METHOD']     = 'GET';
         $_SERVER['REQUEST_URI']        = '/some/path/callback/verifytokenkey';
         $_SERVER['CONTENT_TYPE']       = 'application/atom+xml';

--- a/test/PubSubHubbub/SubscriberTest.php
+++ b/test/PubSubHubbub/SubscriberTest.php
@@ -29,6 +29,13 @@ class SubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (! class_exists('Zend\Db\Adapter\Adapter')) {
+            $this->markTestSkipped(
+                'Skipping tests against zend-db functionality until that '
+                . 'component is forwards-compatible with zend-servicemanager v3'
+            );
+        }
+
         $client = new HttpClient;
         PubSubHubbub::setHttpClient($client);
         $this->subscriber = new Subscriber;

--- a/test/Reader/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Reader/ExtensionPluginManagerCompatibilityTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-feed for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Reader;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Feed\Reader\Exception\InvalidArgumentException;
+use Zend\Feed\Reader\ExtensionPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ExtensionPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ExtensionPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return;
+    }
+
+    public function testInstanceOfMatches()
+    {
+        $this->markTestSkipped(sprintf(
+            'Skipping test; %s allows multiple extension types',
+            ExtensionPluginManager::class
+        ));
+    }
+}

--- a/test/Writer/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Writer/ExtensionPluginManagerCompatibilityTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-feed for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Feed\Writer;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Feed\Writer\Exception\InvalidArgumentException;
+use Zend\Feed\Writer\ExtensionPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ExtensionPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ExtensionPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return;
+    }
+
+    public function testInstanceOfMatches()
+    {
+        $this->markTestSkipped(sprintf(
+            'Skipping test; %s allows multiple extension types',
+            ExtensionPluginManager::class
+        ));
+    }
+}


### PR DESCRIPTION
Updated `composer.json` to pin to stable versions, and, in the case of zend-stdlib and zend-servicemanager, both v2 and v3 versions.

Updated tests to skip tests that depend on components not yet forwards-compatible with v3 versions; these conditionals can be removed in the future when those components are ready. Travis now removes these components when testing against zend-servicemanager v3.
