### PR TITLE
Add ExtensionManagerInterface to ExtensionPluginManager.

### DIFF
--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -19,6 +19,7 @@ use Zend\ServiceManager\Factory\InvokableFactory;
  * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
  */
 class ExtensionPluginManager extends AbstractPluginManager
+    implements ExtensionManagerInterface
 {
     /**
      * Aliases for default set of extension classes


### PR DESCRIPTION
Perhaps there is a reason for this omission, but it seems potentially accidental to me.

My use case is that I need to add/override some plugin services. Previously, I was able to call `\Zend\Feed\Writer\Writer::getExtensionManager()` and then call `setInvokableClass()` on the resulting object. The refactoring to use `StandaloneExtensionManager` broke this technique, since that new static default does not define full plugin manager functionality (thus, `setInvokableClass` is undefined).

It seems that one possible solution to my problem is to create and inject the necessary custom plugin manager, like this:

```
    $manager = new ExtensionPluginManager();
    $manager->setInvokableClass(...);
    Writer::setExtensionManager($manager);
```

However, the `setExtensionManager` call fails because `ExtensionPluginManager` does not conform to the `ExtensionManagerInterface`. If I simply add the required interface, then my code works as expected.

I understand that there is currently some work going on to refactor from the existing static approach to something more dynamic. I would support that -- adding/overriding plugins in this code is currently unnecessarily painful! But I submit this pull request in case this helps me move forward with my code in the meantime, and in case it helps with anyone else's backward compatibility issues.
