### PR TITLE
Re-enable cache/db/validator tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-cache zendframework/zend-db zendframework/zend-validator ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-db": "^2.5",
-        "zendframework/zend-cache": "^2.5",
-        "zendframework/zend-http": "^2.5",
+        "zendframework/zend-db": "^2.7",
+        "zendframework/zend-cache": "^2.6",
+        "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-validator": "^2.5",
+        "zendframework/zend-validator": "^2.6",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0",
         "psr/http-message": "^1.0"

--- a/test/PubSubHubbub/Model/SubscriptionTest.php
+++ b/test/PubSubHubbub/Model/SubscriptionTest.php
@@ -26,13 +26,6 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllOperations()
     {
-        if (! class_exists(DbAdapter::class)) {
-            $this->markTestSkipped(
-                'Skipping tests against zend-db functionality until that '
-                . 'component is forwards-compatible with zend-servicemanager v3'
-            );
-        }
-
         $adapter = $this->initDb();
         $table = new TableGateway('subscription', $adapter);
 
@@ -73,13 +66,6 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testCurrentTimeSetterAndGetter()
     {
-        if (! class_exists(DbAdapter::class)) {
-            $this->markTestSkipped(
-                'Skipping tests against zend-db functionality until that '
-                . 'component is forwards-compatible with zend-servicemanager v3'
-            );
-        }
-
         $now = new DateTime();
         $subscription = new Subscription(new TableGateway('subscription', $this->initDb()));
         $subscription->setNow($now);

--- a/test/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/test/PubSubHubbub/Subscriber/CallbackTest.php
@@ -37,13 +37,6 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'Skipping tests against zend-db functionality until that '
-                . 'component is forwards-compatible with zend-servicemanager v3'
-            );
-        }
-
         $this->_callback = new CallbackSubscriber;
 
         $this->_adapter      = $this->_getCleanMock(

--- a/test/PubSubHubbub/SubscriberTest.php
+++ b/test/PubSubHubbub/SubscriberTest.php
@@ -29,13 +29,6 @@ class SubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (! class_exists('Zend\Db\Adapter\Adapter')) {
-            $this->markTestSkipped(
-                'Skipping tests against zend-db functionality until that '
-                . 'component is forwards-compatible with zend-servicemanager v3'
-            );
-        }
-
         $client = new HttpClient;
         PubSubHubbub::setHttpClient($client);
         $this->subscriber = new Subscriber;


### PR DESCRIPTION
Now that zend-cache, zend-db, and zend-validator all have stable, forwards-compatible releases, we can re-enable these tests.
