### PR TITLE
PHPDoc fixes for date values

### DIFF
--- a/src/Reader/Feed/Atom.php
+++ b/src/Reader/Feed/Atom.php
@@ -104,7 +104,7 @@ class Atom extends AbstractFeed
     /**
      * Get the feed creation date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
     public function getDateCreated()
     {
@@ -126,7 +126,7 @@ class Atom extends AbstractFeed
     /**
      * Get the feed modification date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
     public function getDateModified()
     {

--- a/src/Reader/Feed/FeedInterface.php
+++ b/src/Reader/Feed/FeedInterface.php
@@ -41,14 +41,14 @@ interface FeedInterface extends Iterator, Countable
     /**
      * Get the feed creation date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
     public function getDateCreated();
 
     /**
      * Get the feed modification date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
     public function getDateModified();
 

--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -173,7 +173,7 @@ class Rss extends AbstractFeed
     /**
      * Get the feed creation date
      *
-     * @return string|null
+     * @return DateTime|null
      */
     public function getDateCreated()
     {

--- a/test/Reader/Feed/AtomTest.php
+++ b/test/Reader/Feed/AtomTest.php
@@ -81,6 +81,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('My Title', $feed->getTitle());
     }
 
+    public function testGetsTitleNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getTitle());
+    }
+
     /**
      * Get Authors (Unencoded Text)
      */
@@ -141,6 +149,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['name'=>'Joe Bloggs', 'email'=>'joe@example.com', 'uri'=>'http://www.example.com'], $feed->getAuthor());
     }
 
+    public function testGetsSingleAuthorNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getAuthor());
+    }
+
     /**
      * Get creation date (Unencoded Text)
      */
@@ -162,6 +178,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($edate, $feed->getDateCreated());
     }
 
+    public function testGetsDateCreatedNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getDateCreated());
+    }
+
     /**
      * Get modification date (Unencoded Text)
      */
@@ -181,6 +205,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         );
         $edate = DateTime::createFromFormat(DateTime::ATOM, '2009-03-07T08:03:50Z');
         $this->assertEquals($edate, $feed->getDateModified());
+    }
+
+    public function testGetsDateModifiedNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getDateModified());
     }
 
     /**
@@ -213,6 +245,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Zend_Feed', $feed->getGenerator());
     }
 
+    public function testGetsGeneratorNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getGenerator());
+    }
+
     /**
      * Get Copyright (Unencoded Text)
      */
@@ -230,6 +270,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/copyright/plain/atom10.xml')
         );
         $this->assertEquals('Copyright 2008', $feed->getCopyright());
+    }
+
+    public function testGetsCopyrightNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getCopyright());
     }
 
     /**
@@ -251,6 +299,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('My Description', $feed->getDescription());
     }
 
+    public function testGetsDescriptionNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getDescription());
+    }
+
     /**
      * Get Id (Unencoded Text)
      */
@@ -270,6 +326,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('123', $feed->getId());
     }
 
+    public function testGetsIdNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getId());
+    }
+
     /**
      * Get Language (Unencoded Text)
      */
@@ -287,6 +351,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/language/plain/atom10.xml')
         );
         $this->assertEquals('en-GB', $feed->getLanguage());
+    }
+
+    public function testGetsLanguageNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getLanguage());
     }
 
     /**
@@ -322,6 +394,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/link/plain/atom10-relative.xml')
         );
         $this->assertEquals('http://www.example.com', $feed->getLink());
+    }
+
+    public function testGetsLinkNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getLink());
     }
 
     /**
@@ -369,6 +449,14 @@ class AtomTest extends \PHPUnit_Framework_TestCase
         );
         $feed->setOriginalSourceUri('http://www.example.com/feed/atom');
         $this->assertEquals('http://www.example.com/feed/atom', $feed->getFeedLink());
+    }
+
+    public function testGetsFeedLinkNullFromEmpty()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/empty.xml')
+        );
+        $this->assertNull($feed->getFeedLink());
     }
 
     /**

--- a/test/Reader/Feed/_files/Atom/empty.xml
+++ b/test/Reader/Feed/_files/Atom/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed version="0.3" xmlns="http://purl.org/atom/ns#">
+</feed>


### PR DESCRIPTION
The PHPDoc of the feed date values are set as `string|null` but the methods are returning `DateTime`. I changed the PHPDoc for the feed to `DateTime|null`. It also looks like there are unit tests missing that check the `null` part of the return values, so I extended the ATOM tests.
