### PR TITLE
Proper fix for protocol relative link absolutization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#35](https://github.com/zendframework/zend-feed/pull/35) fixed
   "A non-numeric value encountered" in php 7.1
+- [#39](https://github.com/zendframework/zend-feed/pull/39) fixed protocol
+  relative link absolutisation
 - [#40](https://github.com/zendframework/zend-feed/pull/40) fixed service
   manager v3 compatibility aliases in extension plugin managers
 

--- a/src/Reader/FeedSet.php
+++ b/src/Reader/FeedSet.php
@@ -61,6 +61,10 @@ class FeedSet extends ArrayObject
 
     /**
      *  Attempt to turn a relative URI into an absolute URI
+     *
+     *  @param string $link
+     *  @param string $uri OPTIONAL
+     *  @return string|null absolutised link or null if invalid
      */
     protected function absolutiseUri($link, $uri = null)
     {
@@ -89,12 +93,28 @@ class FeedSet extends ArrayObject
         return $link;
     }
 
+    /**
+     * Resolves scheme relative link to absolute
+     *
+     * @param string $link
+     * @param string $scheme
+     * @return string
+     */
     private function resolveSchemeRelativeUri($link, $scheme)
     {
         $link = ltrim($link, '/');
         return sprintf('%s://%s', $scheme, $link);
     }
 
+    /**
+     *  Resolves relative link to absolute
+     *
+     *  @param string $link
+     *  @param string $scheme
+     *  @param string $host
+     *  @param string $uriPath
+     *  @return string
+     */
     private function resolveRelativeUri($link, $scheme, $host, $uriPath)
     {
         if ($link[0] !== '/') {

--- a/src/Reader/FeedSet.php
+++ b/src/Reader/FeedSet.php
@@ -68,21 +68,25 @@ class FeedSet extends ArrayObject
         if (! $linkUri->isAbsolute() or ! $linkUri->isValid()) {
             if ($uri !== null) {
                 $uri = Uri::factory($uri);
-
+            }
+            if ($linkUri->getHost()) {
+                // protocol relative
+                $scheme = $uri && $uri->getScheme() ? $uri->getScheme() : 'http';
+                $link = sprintf('%s://%s', $scheme, ltrim($link, '/'));
+            } elseif ($uri !== null) {
                 if ($link[0] !== '/') {
                     $link = $uri->getPath() . '/' . $link;
                 }
-
                 $link   = sprintf(
                     '%s://%s/%s',
                     ($uri->getScheme() ?: 'http'),
                     $uri->getHost(),
                     $this->canonicalizePath($link)
                 );
+            }
 
-                if (! Uri::factory($link)->isValid()) {
-                    $link = null;
-                }
+            if (! Uri::factory($link)->isValid()) {
+                $link = null;
             }
         }
         return $link;

--- a/test/Reader/FeedSetTest.php
+++ b/test/Reader/FeedSetTest.php
@@ -28,7 +28,7 @@ class FeedSetTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider linkAndUriProvider
      */
-    public function testAbsolutiseUri($link, $uri, $result = 'http://example.com/feed')
+    public function testAbsolutiseUri($link, $uri, $result)
     {
         $method = new ReflectionMethod('Zend\Feed\Reader\FeedSet', 'absolutiseUri');
         $method->setAccessible(true);
@@ -39,10 +39,14 @@ class FeedSetTest extends PHPUnit_Framework_TestCase
     public function linkAndUriProvider()
     {
         return [
-            'fully-qualified'   => ['feed', 'http://example.com'],
-            'scheme-relative'   => ['feed', '//example.com'],
-            'protocol-relative' => ['//example.com/feed', 'https://example.org', 'https://example.com/feed'],
-            'protocol-relative-default' => ['//example.com/feed', '//example.org'],
+            'fully-qualified' => ['feed', 'http://example.com', 'http://example.com/feed'],
+            'default-scheme' => ['feed', '//example.com', 'http://example.com/feed'],
+            'relative-path' => ['./feed', 'http://example.com/page', 'http://example.com/page/feed'],
+            'relative-path-parent' => ['../feed', 'http://example.com/page', 'http://example.com/feed'],
+            'scheme-relative' => ['//example.com/feed', 'https://example.org', 'https://example.com/feed'],
+            'scheme-relative-default' => ['//example.com/feed', '//example.org', 'http://example.com/feed'],
+            'invalid-absolute' => ['ftp://feed', 'http://example.com', null],
+            'invalid' => ['', null, null],
         ];
     }
 }

--- a/test/Reader/FeedSetTest.php
+++ b/test/Reader/FeedSetTest.php
@@ -28,12 +28,12 @@ class FeedSetTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider linkAndUriProvider
      */
-    public function testAbsolutiseUri($link, $uri)
+    public function testAbsolutiseUri($link, $uri, $result = 'http://example.com/feed')
     {
         $method = new ReflectionMethod('Zend\Feed\Reader\FeedSet', 'absolutiseUri');
         $method->setAccessible(true);
 
-        $this->assertEquals('http://example.com/feed', $method->invoke($this->feedSet, $link, $uri));
+        $this->assertEquals($result, $method->invoke($this->feedSet, $link, $uri));
     }
 
     public function linkAndUriProvider()
@@ -41,7 +41,8 @@ class FeedSetTest extends PHPUnit_Framework_TestCase
         return [
             'fully-qualified'   => ['feed', 'http://example.com'],
             'scheme-relative'   => ['feed', '//example.com'],
-            'double-slash-path' => ['//feed','//example.com'],
+            'protocol-relative' => ['//example.com/feed', 'https://example.org', 'https://example.com/feed'],
+            'protocol-relative-default' => ['//example.com/feed', '//example.org'],
         ];
     }
 }


### PR DESCRIPTION
Fixes #25
Proper fix for #2 

Test before fix:
```
1) ZendTest\Feed\Reader\FeedSetTest::testAbsolutiseUri with data set "protocol-relative" ('//example.com/feed', 'https://example.org', 'https://example.com/feed')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'https://example.com/feed'
+'https://example.org/example.com/feed'

test/Reader/FeedSetTest.php:36

2) ZendTest\Feed\Reader\FeedSetTest::testAbsolutiseUri with data set "protocol-relative-default" ('//example.com/feed', '//example.org')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'http://example.com/feed'
+'http://example.org/example.com/feed'

test/Reader/FeedSetTest.php:36
```