### PR TITLE
Fixed typo in composer.json suggest block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
         "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
-        "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries ehen using the Writer subcomponent"
+        "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries when using the Writer subcomponent"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
I found a typo in the suggestions made by this package while installing Craft CMS 3. Fixed it for you.