### PR TITLE
Setting a title of '0' will cause an exception to be thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#68](https://github.com/zendframework/zend-feed/pull/68) no longer throw an exception for entry titles which have a string value of `0`.
 
 ## 2.9.0 - 2017-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#68](https://github.com/zendframework/zend-feed/pull/68) no longer throw an exception for entry titles which have a string value of `0`.
+- [#68](https://github.com/zendframework/zend-feed/pull/68) updates both `Zend\Feed\Writer\AbstractFeed` and `Zend\Feed\Writer\Entry`
+  to no longer throw an exception for entry titles which have a string value of `0`.
 
 ## 2.9.0 - 2017-12-04
 

--- a/src/Writer/AbstractFeed.php
+++ b/src/Writer/AbstractFeed.php
@@ -421,7 +421,7 @@ class AbstractFeed
      */
     public function setTitle($title)
     {
-        if (empty($title) || ! is_string($title)) {
+        if ((empty($title) && ! is_numeric($title)) || ! is_string($title)) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter must be a non-empty string');
         }
         $this->data['title'] = $title;

--- a/src/Writer/Entry.php
+++ b/src/Writer/Entry.php
@@ -364,7 +364,7 @@ class Entry
      */
     public function setTitle($title)
     {
-        if (empty($title) || ! is_string($title)) {
+        if ((empty($title) && ! is_numeric($title)) || ! is_string($title)) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter must be a non-empty string');
         }
         $this->data['title'] = $title;

--- a/test/Writer/EntryTest.php
+++ b/test/Writer/EntryTest.php
@@ -730,4 +730,11 @@ class EntryTest extends TestCase
 
         $this->assertSame($result, $entry);
     }
+
+    public function testSetTitleShouldAllowAStringWithTheContentsZero()
+    {
+        $entry = new Writer\Entry();
+        $entry->setTitle('0');
+        $this->assertEquals('0', $entry->getTitle());
+    }
 }

--- a/test/Writer/FeedTest.php
+++ b/test/Writer/FeedTest.php
@@ -1081,4 +1081,11 @@ EOT;
 
         $this->assertSame($return, $writer);
     }
+
+    public function testSetTitleShouldAllowAStringWithTheContentsZero()
+    {
+        $feed = new Writer\Feed();
+        $feed->setTitle('0');
+        $this->assertEquals('0', $feed->getTitle());
+    }
 }


### PR DESCRIPTION
Currently if a string of '0' is provided as a title, an exception will be thrown.

This change will still reject strings that are truly empty, but now accept a string value of '0'.

This might feel a bit edge case, but we've seen it in production hence the PR.