### PR TITLE
Remove usage of HTTP_RAW_POST_DATA

### DIFF
--- a/src/PubSubHubbub/AbstractCallback.php
+++ b/src/PubSubHubbub/AbstractCallback.php
@@ -288,9 +288,6 @@ abstract class AbstractCallback implements CallbackInterface
     {
         // @codingStandardsIgnoreEnd
         $body = file_get_contents('php://input');
-        if (strlen(trim($body)) == 0 && isset($GLOBALS['HTTP_RAW_POST_DATA'])) {
-            $body = $GLOBALS['HTTP_RAW_POST_DATA'];
-        }
         if (strlen(trim($body)) > 0) {
             return $body;
         }

--- a/src/PubSubHubbub/AbstractCallback.php
+++ b/src/PubSubHubbub/AbstractCallback.php
@@ -34,6 +34,17 @@ abstract class AbstractCallback implements CallbackInterface
     protected $httpResponse = null;
 
     /**
+     * The input stream to use when retrieving the request body. Defaults to
+     * php://input, but can be set to another value in order to force usage
+     * of another input method. This should primarily be used for testing
+     * purposes.
+     *
+     * @var string|resource String indicates a filename or stream to open;
+     *     resource indicates an already created stream to use.
+     */
+    protected $inputStream = 'php://input';
+
+    /**
      * The number of Subscribers for which any updates are on behalf of.
      *
      * @var int
@@ -287,10 +298,10 @@ abstract class AbstractCallback implements CallbackInterface
     protected function _getRawBody()
     {
         // @codingStandardsIgnoreEnd
-        $body = file_get_contents('php://input');
-        if (strlen(trim($body)) > 0) {
-            return $body;
-        }
-        return false;
+        $body = is_resource($this->inputStream)
+            ? stream_get_contents($this->inputStream)
+            : file_get_contents($this->inputStream);
+
+        return strlen(trim($body)) > 0 ? $body : false;
     }
 }


### PR DESCRIPTION
This patch replaces #16, as it incorporates its changes, and updates tests to address the change in functionality.

Prior to the patch, we would retrive content using `php://input`, falling back to `$GLOBALS['HTTP_RAW_POST_DATA']` if no content was found; this was necessary prior to PHP 5.6 as you could only read `php://input` once. With PHP 5.6 and above, `php://input` can be read multiple times, making the fallback unnecessary.

The changes in this patch that differ from #16 are that they update the tests to no longer use `HTTP_RAW_POST_DATA` as a mechanism for providing input for the `AbstractCallback` implementations.