### PR TITLE
Updates iTunes podcast feed and entry support to latest spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- [#75](https://github.com/zendframework/zend-feed/pull/75) deprecates `Zend\Feed\Reader\Extension\Podcast\Feed::getKeywords()`, as the iTunes Podcast RSS
+  specification no longer supports it.
 
 ### Removed
 
@@ -32,7 +33,20 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisodeType()`, corresponding to the
+  `itunes:episodeType` tag, and returning the type of episode the entry represents
+  (one of "full", "trailer", or "bonus", and defaulting to "full").
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisode()`, corresponding to the
+  `itunes:episode` tag, and returning the number of the episode the entry represents.
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Feed::isComplete()`, corresponding to the
+  `itunes:complete` tag. It returns a boolean, indicating whether or not the podcast is
+  complete (will not air new episodes).
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Feed::getPodcastType()`, corresponding to the
+  `itunes:type` tag, and providing the podcast type (one of "serial" or "episodic", defaulting
+  to the latter).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file, in reverse 
   - `Zend\Feed\Writer\Extension\ITunes\Entry`, via `setItunesImage()`; previously only the `Feed` supported it.
   - `Zend\Feed\Writer\Extension\ITunes\Renderer\Entry`; previously on the `Feed` supported it.
 
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setItunesSeason()`, corresponding to the
+  `itunes:season` tag, and allowing setting the season number of the episode the
+  entry represents.
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setItunesIsClosedCaptioned()`, corresponding to the
+  `itunes:isClosedCaptioned` tag, and allowing setting the status of closed
+  captioning support in the episode the entry represents.
+
 - [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setItunesEpisodeType()`, corresponding to the
   `itunes:episodeType` tag, and allowing setting the type of episode the entry represents
   (one of "full", "trailer", or "bonus", and defaulting to "full").
@@ -28,6 +36,13 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisodeType()`, corresponding to the
   `itunes:episodeType` tag, and returning the type of episode the entry represents
   (one of "full", "trailer", or "bonus", and defaulting to "full").
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getSeason()`, corresponding to the
+  `itunes:season` tag, and returning the season number of the episode the entry represents.
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::isClsoedCaptioned()`, corresponding to the
+  `itunes:isClosedCaptioned` tag, and returning the status of closed captioning
+  in the episode the entry represents.
 
 - [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisode()`, corresponding to the
   `itunes:episode` tag, and returning the number of the episode the entry represents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- [#75](https://github.com/zendframework/zend-feed/pull/75) deprecates `Zend\Feed\Reader\Extension\Podcast\Feed::getKeywords()`, as the iTunes Podcast RSS
-  specification no longer supports it.
+- [#75](https://github.com/zendframework/zend-feed/pull/75) deprecates each of:
+  - `Zend\Feed\Reader\Extension\Podcast\Entry::getKeywords()`
+  - `Zend\Feed\Reader\Extension\Podcast\Feed::getKeywords()`
+  - `Zend\Feed\Writer\Extension\ITunes\Entry::setKeywords()`
+  - `Zend\Feed\Writer\Extension\ITunes\Feed::setKeywords()`
+  as the iTunes Podcast RSS specification no longer supports keywords.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setEpisode()`, corresponding to the
   `itunes:episode` tag, and allowing setting the number of the episode the entry represents.
 
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Feed::setItunesComplete()`, corresponding to the
+  `itunes:complete` tag. It allows setting a boolean flag, indicating whether or not the
+  podcast is complete (will not air new episodes).
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Feed::setItunesType()`, corresponding to the
+  `itunes:type` tag, and allowing setting the podcast type (one of "serial" or "episodic").
+
 - [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisodeType()`, corresponding to the
   `itunes:episodeType` tag, and returning the type of episode the entry represents
   (one of "full", "trailer", or "bonus", and defaulting to "full").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ All notable changes to this project will be documented in this file, in reverse 
   - `Zend\Feed\Writer\Extension\ITunes\Entry`, via `setItunesImage()`; previously only the `Feed` supported it.
   - `Zend\Feed\Writer\Extension\ITunes\Renderer\Entry`; previously on the `Feed` supported it.
 
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setItunesEpisodeType()`, corresponding to the
+  `itunes:episodeType` tag, and allowing setting the type of episode the entry represents
+  (one of "full", "trailer", or "bonus", and defaulting to "full").
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Writer\Extension\ITunes\Entry::setEpisode()`, corresponding to the
+  `itunes:episode` tag, and allowing setting the number of the episode the entry represents.
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisodeType()`, corresponding to the
+  `itunes:episodeType` tag, and returning the type of episode the entry represents
+  (one of "full", "trailer", or "bonus", and defaulting to "full").
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Entry::getEpisode()`, corresponding to the
+  `itunes:episode` tag, and returning the number of the episode the entry represents.
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Feed::isComplete()`, corresponding to the
+  `itunes:complete` tag. It returns a boolean, indicating whether or not the podcast is
+  complete (will not air new episodes).
+
+- [#75](https://github.com/zendframework/zend-feed/pull/75) adds `Zend\Feed\Reader\Extension\Podcast\Feed::getPodcastType()`, corresponding to the
+  `itunes:type` tag, and providing the podcast type (one of "serial" or "episodic", defaulting
+  to the latter).
+
 ### Changed
 
 - [#77](https://github.com/zendframework/zend-feed/pull/77) updates URI validation for `Zend\Feed\Writer\Extension\ITunes\Feed::setItunesImage()` to

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -240,6 +240,26 @@ class Entry extends Extension\AbstractEntry
     }
 
     /**
+     * Is the episode closed captioned?
+     *
+     * Returns true only if itunes:isClosedCaptioned has the value 'Yes'.
+     *
+     * @return bool
+     */
+    public function isClosedCaptioned()
+    {
+        if (isset($this->data['isClosedCaptioned'])) {
+            return $this->data['isClosedCaptioned'];
+        }
+
+        $status = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:isClosedCaptioned)');
+
+        $this->data['isClosedCaptioned'] = $status === 'Yes';
+
+        return $this->data['isClosedCaptioned'];
+    }
+
+    /**
      * Register iTunes namespace
      *
      */

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -260,6 +260,28 @@ class Entry extends Extension\AbstractEntry
     }
 
     /**
+     * Get the season number
+     *
+     * @return null|int
+     */
+    public function getSeason()
+    {
+        if (isset($this->data['season'])) {
+            return $this->data['season'];
+        }
+
+        $season = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:season)');
+
+        if (! $season) {
+            $season = null;
+        }
+
+        $this->data['season'] = null === $season ? $season : (int) $season;
+
+        return $this->data['season'];
+    }
+
+    /**
      * Register iTunes namespace
      *
      */

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -188,6 +188,50 @@ class Entry extends Extension\AbstractEntry
     }
 
     /**
+     * Get the episode number
+     *
+     * @return null|int
+     */
+    public function getEpisode()
+    {
+        if (isset($this->data['episode'])) {
+            return $this->data['episode'];
+        }
+
+        $episode = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episode)');
+
+        if (! $episode) {
+            $episode = null;
+        }
+
+        $this->data['episode'] = null === $episode ? $episode : (int) $episode;
+
+        return $this->data['episode'];
+    }
+
+    /**
+     * Get the episode number
+     *
+     * @return string One of "full", "trailer", or "bonus"; defaults to "full".
+     */
+    public function getEpisodeType()
+    {
+        if (isset($this->data['episodeType'])) {
+            return $this->data['episodeType'];
+        }
+
+        $type = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episodeType)');
+
+        if (! $type) {
+            $type = 'full';
+        }
+
+        $this->data['episodeType'] = (string) $type;
+
+        return $this->data['episodeType'];
+    }
+
+    /**
      * Register iTunes namespace
      *
      */

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -102,10 +102,18 @@ class Entry extends Extension\AbstractEntry
     /**
      * Get the entry keywords
      *
+     * @deprecated since 2.10.0; itunes:keywords is no longer part of the
+     *     iTunes podcast RSS specification.
      * @return string
      */
     public function getKeywords()
     {
+        trigger_error(
+            'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
+            . ' and should not be relied on.',
+            \E_USER_DEPRECATED
+        );
+
         if (isset($this->data['keywords'])) {
             return $this->data['keywords'];
         }

--- a/src/Reader/Extension/Podcast/Feed.php
+++ b/src/Reader/Extension/Podcast/Feed.php
@@ -145,10 +145,18 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the entry keywords
      *
+     * @deprecated since 2.10.0; itunes:keywords is no longer part of the
+     *     iTunes podcast RSS specification.
      * @return string
      */
     public function getKeywords()
     {
+        trigger_error(
+            'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
+            . ' and should not be relied on.',
+            \E_USER_DEPRECATED
+        );
+
         if (isset($this->data['keywords'])) {
             return $this->data['keywords'];
         }
@@ -259,6 +267,51 @@ class Feed extends Extension\AbstractFeed
         $this->data['summary'] = $summary;
 
         return $this->data['summary'];
+    }
+
+    /**
+     * Get the type of podcast
+     *
+     * @return string One of "episodic" or "serial". Defaults to "episodic"
+     *     if no itunes:type tag is encountered.
+     */
+    public function getPodcastType()
+    {
+        if (isset($this->data['podcastType'])) {
+            return $this->data['podcastType'];
+        }
+
+        $type = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:type)');
+
+        if (! $type) {
+            $type = 'episodic';
+        }
+
+        $this->data['podcastType'] = (string) $type;
+
+        return $this->data['podcastType'];
+    }
+
+    /**
+     * Is the podcast complete (no more episodes will post)?
+     *
+     * @return bool
+     */
+    public function isComplete()
+    {
+        if (isset($this->data['complete'])) {
+            return $this->data['complete'];
+        }
+
+        $complete = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:complete)');
+
+        if (! $complete) {
+            $complete = false;
+        }
+
+        $this->data['complete'] = $complete === 'Yes';
+
+        return $this->data['complete'];
     }
 
     /**

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -163,12 +163,20 @@ class Entry
     /**
      * Set keywords
      *
+     * @deprecated since 2.10.0; itunes:keywords is no longer part of the
+     *     iTunes podcast RSS specification.
      * @param  array $value
      * @return Entry
      * @throws Writer\Exception\InvalidArgumentException
      */
     public function setItunesKeywords(array $value)
     {
+        trigger_error(
+            'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
+            . ' and should not be relied on.',
+            \E_USER_DEPRECATED
+        );
+
         if (count($value) > 12) {
             throw new Writer\Exception\InvalidArgumentException('invalid parameter: "keywords" may only'
             . ' contain a maximum of 12 terms');
@@ -243,6 +251,50 @@ class Entry
 
         $this->data['image'] = $value;
         return $this;
+    }
+
+    /**
+     * Get the episode number
+     *
+     * @return null|int
+     */
+    public function getEpisode()
+    {
+        if (isset($this->data['episode'])) {
+            return $this->data['episode'];
+        }
+
+        $episode = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episode)');
+
+        if (! $episode) {
+            $episode = null;
+        }
+
+        $this->data['episode'] = null === $episode ? $episode : (int) $episode;
+
+        return $this->data['episode'];
+    }
+
+    /**
+     * Get the episode number
+     *
+     * @return string One of "full", "trailer", or "bonus"; defaults to "full".
+     */
+    public function getEpisodeType()
+    {
+        if (isset($this->data['episodeType'])) {
+            return $this->data['episodeType'];
+        }
+
+        $type = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episodeType)');
+
+        if (! $type) {
+            $type = 'full';
+        }
+
+        $this->data['episodeType'] = (string) $type;
+
+        return $this->data['episodeType'];
     }
 
     /**

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -254,47 +254,47 @@ class Entry
     }
 
     /**
-     * Get the episode number
+     * Set the episode number
      *
-     * @return null|int
+     * @param int $number
+     * @return self
+     * @throws Writer\Exception\InvalidArgumentException
      */
-    public function getEpisode()
+    public function setItunesEpisode($number)
     {
-        if (isset($this->data['episode'])) {
-            return $this->data['episode'];
+        if (! is_numeric($number) || is_float($number)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "number" may only be an integer; received %s',
+                is_object($number) ? get_class($number) : gettype($number)
+            ));
         }
 
-        $episode = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episode)');
+        $this->data['episode'] = (int) $number;
 
-        if (! $episode) {
-            $episode = null;
-        }
-
-        $this->data['episode'] = null === $episode ? $episode : (int) $episode;
-
-        return $this->data['episode'];
+        return $this;
     }
 
     /**
-     * Get the episode number
+     * Set the episode type
      *
-     * @return string One of "full", "trailer", or "bonus"; defaults to "full".
+     * @param string $type One of "full", "trailer", or "bonus".
+     * @return self
+     * @throws Writer\Exception\InvalidArgumentException
      */
-    public function getEpisodeType()
+    public function setItunesEpisodeType($type)
     {
-        if (isset($this->data['episodeType'])) {
-            return $this->data['episodeType'];
+        $validTypes = ['full', 'trailer', 'bonus'];
+        if (! in_array($type, $validTypes, true)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "episodeType" MUST be one of the strings [%s]; received %s',
+                implode(', ', $validTypes),
+                is_object($type) ? get_class($type) : var_export($type, true)
+            ));
         }
 
-        $type = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:episodeType)');
+        $this->data['episodeType'] = $type;
 
-        if (! $type) {
-            $type = 'full';
-        }
-
-        $this->data['episodeType'] = (string) $type;
-
-        return $this->data['episodeType'];
+        return $this;
     }
 
     /**

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -323,6 +323,27 @@ class Entry
     }
 
     /**
+     * Set the season number to which the episode belongs
+     *
+     * @param int $number
+     * @return self
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setItunesSeason($number)
+    {
+        if (! is_numeric($number) || is_float($number)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "season" may only be an integer; received %s',
+                is_object($number) ? get_class($number) : gettype($number)
+            ));
+        }
+
+        $this->data['season'] = (int) $number;
+
+        return $this;
+    }
+
+    /**
      * Overloading to itunes specific setters
      *
      * @param  string $method

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -298,6 +298,31 @@ class Entry
     }
 
     /**
+     * Set the status of closed captioning
+     *
+     * @param bool $status
+     * @return self
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setItunesIsClosedCaptioned($status)
+    {
+        if (! is_bool($status)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "isClosedCaptioned" MUST be a boolean; received %s',
+                is_object($status) ? get_class($status) : var_export($status, true)
+            ));
+        }
+
+        if (! $status) {
+            return $this;
+        }
+
+        $this->data['isClosedCaptioned'] = true;
+
+        return $this;
+    }
+
+    /**
      * Overloading to itunes specific setters
      *
      * @param  string $method

--- a/src/Writer/Extension/ITunes/Feed.php
+++ b/src/Writer/Extension/ITunes/Feed.php
@@ -223,12 +223,20 @@ class Feed
     /**
      * Set feed keywords
      *
+     * @deprecated since 2.10.0; itunes:keywords is no longer part of the
+     *     iTunes podcast RSS specification.
      * @param  array $value
      * @return Feed
      * @throws Writer\Exception\InvalidArgumentException
      */
     public function setItunesKeywords(array $value)
     {
+        trigger_error(
+            'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
+            . ' and should not be relied on.',
+            \E_USER_DEPRECATED
+        );
+
         if (count($value) > 12) {
             throw new Writer\Exception\InvalidArgumentException('invalid parameter: "keywords" may only'
             . ' contain a maximum of 12 terms');

--- a/src/Writer/Extension/ITunes/Feed.php
+++ b/src/Writer/Extension/ITunes/Feed.php
@@ -343,6 +343,51 @@ class Feed
     }
 
     /**
+     * Set podcast type
+     *
+     * @param  string $type
+     * @return Feed
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setItunesType($type)
+    {
+        $validTypes = ['episodic', 'serial'];
+        if (! in_array($type, $validTypes, true)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "type" MUST be one of [%s]; received %s',
+                implode(', ', $validTypes),
+                is_object($type) ? get_class($type) : var_export($type, true)
+            ));
+        }
+        $this->data['type'] = $type;
+        return $this;
+    }
+
+    /**
+     * Set "completion" status (whether more episodes will be released)
+     *
+     * @param  bool $status
+     * @return Feed
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setItunesComplete($status)
+    {
+        if (! is_bool($status)) {
+            throw new Writer\Exception\InvalidArgumentException(sprintf(
+                'invalid parameter: "complete" MUST be boolean; received %s',
+                is_object($status) ? get_class($status) : var_export($status, true)
+            ));
+        }
+
+        if (! $status) {
+            return $this;
+        }
+
+        $this->data['complete'] = 'Yes';
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @param  string $method
@@ -360,6 +405,7 @@ class Feed
                 'invalid method: ' . $method
             );
         }
+
         if (! array_key_exists($point, $this->data) || empty($this->data[$point])) {
             return;
         }

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -43,6 +43,7 @@ class Entry extends Extension\AbstractRenderer
         $this->_setSummary($this->dom, $this->base);
         $this->_setEpisode($this->dom, $this->base);
         $this->_setEpisodeType($this->dom, $this->base);
+        $this->_setClosedCaptioned($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -279,6 +280,28 @@ class Entry extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('itunes:episodeType');
         $text = $dom->createTextNode($type);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set closed captioning status for episode
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setClosedCaptioned(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $status = $this->getDataContainer()->getItunesIsClosedCaptioned();
+        if (! $status) {
+            return;
+        }
+        $el = $dom->createElement('itunes:isClosedCaptioned');
+        $text = $dom->createTextNode('Yes');
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -44,6 +44,7 @@ class Entry extends Extension\AbstractRenderer
         $this->_setEpisode($this->dom, $this->base);
         $this->_setEpisodeType($this->dom, $this->base);
         $this->_setClosedCaptioned($this->dom, $this->base);
+        $this->_setSeason($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -302,6 +303,28 @@ class Entry extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('itunes:isClosedCaptioned');
         $text = $dom->createTextNode('Yes');
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set entry season number
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setSeason(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $season = $this->getDataContainer()->getItunesSeason();
+        if (! $season) {
+            return;
+        }
+        $el = $dom->createElement('itunes:season');
+        $text = $dom->createTextNode($season);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -41,6 +41,8 @@ class Entry extends Extension\AbstractRenderer
         $this->_setKeywords($this->dom, $this->base);
         $this->_setSubtitle($this->dom, $this->base);
         $this->_setSummary($this->dom, $this->base);
+        $this->_setEpisode($this->dom, $this->base);
+        $this->_setEpisodeType($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -233,6 +235,50 @@ class Entry extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('itunes:summary');
         $text = $dom->createTextNode($summary);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set entry episode number
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setEpisode(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $episode = $this->getDataContainer()->getItunesEpisode();
+        if (! $episode) {
+            return;
+        }
+        $el = $dom->createElement('itunes:episode');
+        $text = $dom->createTextNode($episode);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set entry episode type
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setEpisodeType(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $type = $this->getDataContainer()->getItunesEpisodeType();
+        if (! $type) {
+            return;
+        }
+        $el = $dom->createElement('itunes:episodeType');
+        $text = $dom->createTextNode($type);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/ITunes/Renderer/Feed.php
+++ b/src/Writer/Extension/ITunes/Renderer/Feed.php
@@ -44,6 +44,8 @@ class Feed extends Extension\AbstractRenderer
         $this->_setOwners($this->dom, $this->base);
         $this->_setSubtitle($this->dom, $this->base);
         $this->_setSummary($this->dom, $this->base);
+        $this->_setType($this->dom, $this->base);
+        $this->_setComplete($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -322,6 +324,50 @@ class Feed extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('itunes:summary');
         $text = $dom->createTextNode($summary);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set podcast type
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setType(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $type = $this->getDataContainer()->getItunesType();
+        if (! $type) {
+            return;
+        }
+        $el = $dom->createElement('itunes:type');
+        $text = $dom->createTextNode($summary);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set complete status
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setComplete(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $status = $this->getDataContainer()->getItunesComplete();
+        if (! $status) {
+            return;
+        }
+        $el = $dom->createElement('itunes:complete');
+        $text = $dom->createTextNode('Yes');
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/test/Reader/Integration/PodcastRss2Test.php
+++ b/test/Reader/Integration/PodcastRss2Test.php
@@ -373,4 +373,34 @@ class PodcastRss2Test extends TestCase
         $entry = $feed->current();
         $this->assertEquals('bonus', $entry->getEpisodeType());
     }
+
+    public function testIsClosedCaptionedReturnsTrueWhenEpisodeDefinesItWithValueYes()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+        $entry = $feed->current();
+        $this->assertTrue($entry->isClosedCaptioned());
+    }
+
+    public function testIsClosedCaptionedReturnsFalseWhenEpisodeDefinesItWithValueOtherThanYes()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+        $feed->next(); // Second entry uses "No" as value
+        $entry = $feed->current();
+        $this->assertFalse($entry->isClosedCaptioned());
+    }
+
+    public function testIsClosedCaptionedReturnsFalseWhenEpisodeDoesNotDefineIt()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+        $feed->next();
+        $feed->next(); // Third entry does not define it
+        $entry = $feed->current();
+        $this->assertFalse($entry->isClosedCaptioned());
+    }
 }

--- a/test/Reader/Integration/PodcastRss2Test.php
+++ b/test/Reader/Integration/PodcastRss2Test.php
@@ -403,4 +403,23 @@ class PodcastRss2Test extends TestCase
         $entry = $feed->current();
         $this->assertFalse($entry->isClosedCaptioned());
     }
+
+    public function testGetSeasonReturnsNullIfNoTagPresent()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+        $entry = $feed->current();
+        $this->assertNull($entry->getSeason());
+    }
+
+    public function testGetSeasonReturnsValueWhenTagPresent()
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+        $feed->next(); // second item defines the tag
+        $entry = $feed->current();
+        $this->assertEquals(3, $entry->getSeason());
+    }
 }

--- a/test/Reader/Integration/_files/podcast-complete.xml
+++ b/test/Reader/Integration/_files/podcast-complete.xml
@@ -7,6 +7,7 @@
         <link>http://www.example.com/podcasts/everything/index.html</link>
         <language>en-us</language>
         <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
+        <itunes:complete>Yes</itunes:complete>
         <itunes:type>serial</itunes:type>
 		<itunes:explicit>yes</itunes:explicit>
 		<itunes:block>no</itunes:block>
@@ -51,7 +52,6 @@
             <itunes:duration>7:04</itunes:duration>
             <itunes:keywords>salt, pepper, shaker, exciting
             </itunes:keywords>
-            <itunes:image href="https://www.example.com/podcasts/everything/episode.png" />
         </item>
 
         <item>

--- a/test/Reader/Integration/_files/podcast-episode.xml
+++ b/test/Reader/Integration/_files/podcast-episode.xml
@@ -34,6 +34,8 @@
 
         <item>
             <title>Shake Shake Shake Your Spices</title>
+            <itunes:episode>10</itunes:episode>
+            <itunes:episodeType>bonus</itunes:episodeType>
 			<itunes:explicit>no</itunes:explicit>
             <itunes:author>John Doe</itunes:author>
 			<itunes:block>yes</itunes:block>
@@ -51,7 +53,6 @@
             <itunes:duration>7:04</itunes:duration>
             <itunes:keywords>salt, pepper, shaker, exciting
             </itunes:keywords>
-            <itunes:image href="https://www.example.com/podcasts/everything/episode.png" />
         </item>
 
         <item>

--- a/test/Reader/Integration/_files/podcast-incomplete.xml
+++ b/test/Reader/Integration/_files/podcast-incomplete.xml
@@ -7,6 +7,7 @@
         <link>http://www.example.com/podcasts/everything/index.html</link>
         <language>en-us</language>
         <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
+        <itunes:complete>No</itunes:complete>
         <itunes:type>serial</itunes:type>
 		<itunes:explicit>yes</itunes:explicit>
 		<itunes:block>no</itunes:block>
@@ -51,7 +52,6 @@
             <itunes:duration>7:04</itunes:duration>
             <itunes:keywords>salt, pepper, shaker, exciting
             </itunes:keywords>
-            <itunes:image href="https://www.example.com/podcasts/everything/episode.png" />
         </item>
 
         <item>

--- a/test/Reader/Integration/_files/podcast-no-type.xml
+++ b/test/Reader/Integration/_files/podcast-no-type.xml
@@ -7,7 +7,6 @@
         <link>http://www.example.com/podcasts/everything/index.html</link>
         <language>en-us</language>
         <copyright>&#x2117; &amp; &#xA9; 2005 John Doe &amp; Family</copyright>
-        <itunes:type>serial</itunes:type>
 		<itunes:explicit>yes</itunes:explicit>
 		<itunes:block>no</itunes:block>
         <itunes:subtitle>A show about everything</itunes:subtitle>
@@ -51,7 +50,6 @@
             <itunes:duration>7:04</itunes:duration>
             <itunes:keywords>salt, pepper, shaker, exciting
             </itunes:keywords>
-            <itunes:image href="https://www.example.com/podcasts/everything/episode.png" />
         </item>
 
         <item>

--- a/test/Reader/Integration/_files/podcast.xml
+++ b/test/Reader/Integration/_files/podcast.xml
@@ -52,6 +52,7 @@
             <itunes:keywords>salt, pepper, shaker, exciting
             </itunes:keywords>
             <itunes:image href="https://www.example.com/podcasts/everything/episode.png" />
+            <itunes:isClosedCaptioned>Yes</itunes:isClosedCaptioned>
         </item>
 
         <item>
@@ -71,6 +72,7 @@
             <itunes:duration>4:34</itunes:duration>
             <itunes:keywords>metric, socket, wrenches, tool
             </itunes:keywords>
+            <itunes:isClosedCaptioned>No</itunes:isClosedCaptioned>
         </item>
 
         <item>

--- a/test/Reader/Integration/_files/podcast.xml
+++ b/test/Reader/Integration/_files/podcast.xml
@@ -73,6 +73,7 @@
             <itunes:keywords>metric, socket, wrenches, tool
             </itunes:keywords>
             <itunes:isClosedCaptioned>No</itunes:isClosedCaptioned>
+            <itunes:season>3</itunes:season>
         </item>
 
         <item>

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -343,4 +343,44 @@ class EntryTest extends TestCase
         $entry->setItunesEpisodeType($type);
         $this->assertEquals($type, $entry->getItunesEpisodeType());
     }
+
+    public function invalidClosedCaptioningFlags()
+    {
+        return [
+            'null'       => [null],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'string'     => ['Yes'],
+            'array'      => [['Yes']],
+            'object'     => [(object) ['isClosedCaptioned' => 'Yes']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidClosedCaptioningFlags
+     * @param mixed $status
+     */
+    public function testSettingClosedCaptioningToNonBooleanRaisesException($status)
+    {
+        $entry = new Writer\Entry();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('MUST be a boolean');
+        $entry->setItunesIsClosedCaptioned($status);
+    }
+
+    public function testSettingClosedCaptioningToFalseDoesNothing()
+    {
+        $entry = new Writer\Entry();
+        $entry->setItunesIsClosedCaptioned(false);
+        $this->assertNull($entry->getItunesIsClosedCaptioned());
+    }
+
+    public function testSettingClosedCaptioningToTrueUpdatesContainer()
+    {
+        $entry = new Writer\Entry();
+        $entry->setItunesIsClosedCaptioned(true);
+        $this->assertTrue($entry->getItunesIsClosedCaptioned());
+    }
 }

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -262,4 +262,85 @@ class EntryTest extends TestCase
         $entry->setItunesImage($url);
         $this->assertEquals($url, $entry->getItunesImage());
     }
+
+    public function nonNumericEpisodeNumbers()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero-float' => [0.000],
+            'float'      => [1.1],
+            'string'     => ['not-a-number'],
+            'array'      => [[1]],
+            'object'     => [(object) ['number' => 1]],
+        ];
+    }
+
+    /**
+     * @dataProvider nonNumericEpisodeNumbers
+     * @param mixed $number
+     */
+    public function testSetEpisodeRaisesExceptionForNonNumericEpisodeNumbers($number)
+    {
+        $entry = new Writer\Entry();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('may only be an integer');
+        $entry->setItunesEpisode($number);
+    }
+
+    public function testSetEpisodeSetsNumberInEntry()
+    {
+        $entry = new Writer\Entry();
+        $entry->setItunesEpisode(42);
+        $this->assertEquals(42, $entry->getItunesEpisode());
+    }
+
+    public function invalidEpisodeTypes()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'string'     => ['not-a-type'],
+            'array'      => [['full']],
+            'object'     => [(object) ['type' => 'full']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidEpisodeTypes
+     * @param mixed $type
+     */
+    public function testSetEpisodeTypeRaisesExceptionForInvalidTypes($type)
+    {
+        $entry = new Writer\Entry();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('MUST be one of');
+        $entry->setItunesEpisodeType($type);
+    }
+
+    public function validEpisodeTypes()
+    {
+        return [
+            'full'    => ['full'],
+            'trailer' => ['trailer'],
+            'bonus'   => ['bonus'],
+        ];
+    }
+
+    /**
+     * @dataProvider validEpisodeTypes
+     * @param string $type
+     */
+    public function testEpisodeTypeMaybeMutatedWithAcceptedValues($type)
+    {
+        $entry = new Writer\Entry();
+        $entry->setItunesEpisodeType($type);
+        $this->assertEquals($type, $entry->getItunesEpisodeType());
+    }
 }

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -383,4 +383,23 @@ class EntryTest extends TestCase
         $entry->setItunesIsClosedCaptioned(true);
         $this->assertTrue($entry->getItunesIsClosedCaptioned());
     }
+
+    /**
+     * @dataProvider nonNumericEpisodeNumbers
+     * @param mixed $number
+     */
+    public function testSetSeasonRaisesExceptionForNonNumericSeasonNumbers($number)
+    {
+        $entry = new Writer\Entry();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('may only be an integer');
+        $entry->setItunesSeason($number);
+    }
+
+    public function testSetSeasonSetsNumberInEntry()
+    {
+        $entry = new Writer\Entry();
+        $entry->setItunesSeason(42);
+        $this->assertEquals(42, $entry->getItunesSeason());
+    }
 }

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -137,28 +137,52 @@ class EntryTest extends TestCase
         $words = [
             'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12'
         ];
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
         $entry->setItunesKeywords($words);
+        restore_error_handler();
+
         $this->assertEquals($words, $entry->getItunesKeywords());
     }
 
     public function testSetKeywordsThrowsExceptionIfMaxKeywordsExceeded()
     {
-        $this->expectException(ExceptionInterface::class);
         $entry = new Writer\Entry;
         $words = [
             'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12', 'a13'
         ];
-        $entry->setItunesKeywords($words);
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
+        try {
+            $entry->setItunesKeywords($words);
+            $this->fail('Expected exception when setting more keywords than allowed');
+        } catch (ExceptionInterface $e) {
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testSetKeywordsThrowsExceptionIfFormattedKeywordsExceeds255CharLength()
     {
-        $this->expectException(ExceptionInterface::class);
         $entry = new Writer\Entry;
         $words = [
             str_repeat('a', 253), str_repeat('b', 2)
         ];
-        $entry->setItunesKeywords($words);
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
+        try {
+            $entry->setItunesKeywords($words);
+            $this->fail('Expected exception when setting keywords exceeding character length');
+        } catch (ExceptionInterface $e) {
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testSetSubtitle()

--- a/test/Writer/Extension/ITunes/FeedTest.php
+++ b/test/Writer/Extension/ITunes/FeedTest.php
@@ -341,4 +341,91 @@ class FeedTest extends TestCase
         $feed->setItunesImage($url);
         $this->assertEquals($url, $feed->getItunesImage());
     }
+
+    public function invalidPodcastTypes()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'string'     => ['not-a-type'],
+            'array'      => [['episodic']],
+            'object'     => [(object) ['type' => 'episodic']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidPodcastTypes
+     * @param mixed $type
+     */
+    public function testSetItunesTypeWithInvalidTypeRaisesException($type)
+    {
+        $feed = new Writer\Feed();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('MUST be one of');
+        $feed->setItunesType($type);
+    }
+
+    public function validPodcastTypes()
+    {
+        return [
+            'episodic' => ['episodic'],
+            'serial'   => ['serial'],
+        ];
+    }
+
+    /**
+     * @dataProvider validPodcastTypes
+     * @param mixed $type
+     */
+    public function testSetItunesTypeMutatesTypeWithValidData($type)
+    {
+        $feed = new Writer\Feed();
+        $feed->setItunesType($type);
+        $this->assertEquals($type, $feed->getItunesType());
+    }
+
+    public function invalidCompleteStatuses()
+    {
+        return [
+            'null'       => [null],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'string'     => ['not-a-status'],
+            'array'      => [[true]],
+            'object'     => [(object) ['complete' => true]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidCompleteStatuses
+     * @param mixed $status
+     */
+    public function testSetItunesCompleteRaisesExceptionForInvalidStatus($status)
+    {
+        $feed = new Writer\Feed();
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('MUST be boolean');
+        $feed->setItunesComplete($status);
+    }
+
+    public function testSetItunesCompleteWithTrueSetsDataInContainer()
+    {
+        $feed = new Writer\Feed();
+        $feed->setItunesComplete(true);
+        $this->assertEquals('Yes', $feed->getItunesComplete());
+    }
+
+    public function testSetItunesCompleteWithFalseDoesNotSetDataInContainer()
+    {
+        $feed = new Writer\Feed();
+        $feed->setItunesComplete(false);
+        $this->assertNull($feed->getItunesComplete());
+    }
 }

--- a/test/Writer/Extension/ITunes/FeedTest.php
+++ b/test/Writer/Extension/ITunes/FeedTest.php
@@ -188,28 +188,52 @@ class FeedTest extends TestCase
         $words = [
             'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12'
         ];
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
         $feed->setItunesKeywords($words);
+        restore_error_handler();
+
         $this->assertEquals($words, $feed->getItunesKeywords());
     }
 
     public function testSetKeywordsThrowsExceptionIfMaxKeywordsExceeded()
     {
-        $this->expectException(ExceptionInterface::class);
         $feed = new Writer\Feed;
         $words = [
             'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12', 'a13'
         ];
-        $feed->setItunesKeywords($words);
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
+        try {
+            $feed->setItunesKeywords($words);
+            $this->fail('Expected exception when setting more keywords than allowed');
+        } catch (ExceptionInterface $e) {
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testSetKeywordsThrowsExceptionIfFormattedKeywordsExceeds255CharLength()
     {
-        $this->expectException(ExceptionInterface::class);
         $feed = new Writer\Feed;
         $words = [
             str_repeat('a', 253), str_repeat('b', 2)
         ];
-        $feed->setItunesKeywords($words);
+
+        set_error_handler(function ($errno, $errstr) {
+            return (bool) preg_match('/itunes:keywords/', $errstr);
+        }, \E_USER_DEPRECATED);
+        try {
+            $feed->setItunesKeywords($words);
+            $this->fail('Expected exception when setting keywords exceeding character length');
+        } catch (ExceptionInterface $e) {
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testSetNewFeedUrl()


### PR DESCRIPTION
Makes the following changes to the `Zend\Feed\Reader\Extension\Podcast` and `Zend\Feed\Writer\Extension\ITunes` namespaces (which map to the `itunes` RSS extension):

- Deprecates `Feed::(get|set|add)Keywords()` and `Entry::(get|set|add)Keywords(), as the spec no longer supports it.
- Adds `Feed::isComplete()`/`Feed::setItunesComplete()` (mapping to `itunes:complete`), for retrieving/setting if a podcast is complete (no more episodes will occur).
- Adds `Feed::getPodcastType()`/`Feed:setItunesType()` (mapping to `itunes:type`), for retrieving/setting the podcast type (one of "serial" or "episodic", the latter being the default).
- Adds `Entry::getEpisode()`/`Entry::setItunesEpisode()` (mapping to `itunes:episode`), for retrieving/setting the current episode number.
- Adds `Entry::getEpisodeType()`/`Entry::setItunesEpisodeType()` (mapping to `itunes:episodeType`), for retrieving/setting the current episode type (one of "full", "trailer", or "bonus").
- Adds `Entry::isClosedCaptioned()`/`Entry::setItunesIsClosedCaptioned()` (mapping to `itunes:isClosedCaptioned`), for retrieving/setting closed captioning status.
- Adds `Entry::getSeason()`/`Entry::setItunesSeason()` (mapping to `itunes:season`), for retrieving/setting the season to which an episode belongs.

Fixes #66