### PR TITLE
Allow usage of Reader without GooglePlayPodcast extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,19 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#81](https://github.com/zendframework/zend-feed/pull/81) updates the `Zend\Feed\Reader\Reader` and `Zend\Feed\Writer\Writer` classes to
+  conditionally register their respective "GooglePlayPodcast" extensions only if
+  their extension managers are aware of it. This is done due to the fact that
+  existing `ExtensionManagerInterface` implementations may not register it by
+  default as the extension did not exist in releases prior to 2.10.0. By having
+  the registration conditional, we prevent an exception from being raised; users
+  are not impacted by its absence, as the extension features were not exposed
+  previously.
+  
+  Both `Reader` and `Writer` emit an `E_USER_NOTICE` when the extension is not
+  found in the extension manager, indicating that the
+  `ExtensionManagerInterface` implementation should be updated to add entries
+  for the "GooglePlayPodcast" entry, feed, and/or renderer classes.
 
 ## 2.10.1 - 2018-06-05
 

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -577,19 +577,24 @@ class Reader implements ReaderImportInterface
      */
     public static function registerExtension($name)
     {
+        $manager   = static::getExtensionManager();
         $feedName  = $name . '\Feed';
         $entryName = $name . '\Entry';
-        $manager   = static::getExtensionManager();
+
         if (static::isRegistered($name)) {
             if ($manager->has($feedName) || $manager->has($entryName)) {
                 return;
             }
         }
 
-        if (! $manager->has($feedName) && ! $manager->has($entryName)) {
-            throw new Exception\RuntimeException('Could not load extension: ' . $name
-                . ' using Plugin Loader. Check prefix paths are configured and extension exists.');
+        if (! static::hasExtension($name)) {
+            throw new Exception\RuntimeException(sprintf(
+                'Could not load extension "%s" using Plugin Loader.'
+                . ' Check prefix paths are configured and extension exists.',
+                $name
+            ));
         }
+
         if ($manager->has($feedName)) {
             static::$extensions['feed'][] = $feedName;
         }
@@ -672,7 +677,18 @@ class Reader implements ReaderImportInterface
         static::registerExtension('WellFormedWeb');
         static::registerExtension('Thread');
         static::registerExtension('Podcast');
-        static::registerExtension('GooglePlayPodcast');
+
+        // Added in 2.10.0; check for it conditionally
+        static::hasExtension('GooglePlayPodcast')
+            ? static::registerExtension('GooglePlayPodcast')
+            : trigger_error(
+                sprintf(
+                    'Please update your %1$s\ExtensionManagerInterface implementation to add entries for'
+                    . ' %1$s\Extension\GooglePlayPodcast\Entry and %1$s\Extension\GooglePlayPodcast\Feed.',
+                    __NAMESPACE__
+                ),
+                \E_USER_NOTICE
+            );
     }
 
     /**
@@ -692,5 +708,29 @@ class Reader implements ReaderImportInterface
             $value = unserialize($value);
         }
         return $array;
+    }
+
+    /**
+     * Does the extension manager have the named extension?
+     *
+     * This method exists to allow us to test if an extension is present in the
+     * extension manager. It may be used by registerExtension() to determine if
+     * the extension has items present in the manager, or by
+     * registerCoreExtension() to determine if the core extension has entries
+     * in the extension manager. In the latter case, this can be useful when
+     * adding new extensions in a minor release, as custom extension manager
+     * implementations may not yet have an entry for the extension, which would
+     * then otherwise cause registerExtension() to fail.
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected static function hasExtension($name)
+    {
+        $feedName  = $name . '\Feed';
+        $entryName = $name . '\Entry';
+        $manager   = static::getExtensionManager();
+
+        return $manager->has($feedName) || $manager->has($entryName);
     }
 }

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -577,16 +577,6 @@ class Reader implements ReaderImportInterface
      */
     public static function registerExtension($name)
     {
-        $manager   = static::getExtensionManager();
-        $feedName  = $name . '\Feed';
-        $entryName = $name . '\Entry';
-
-        if (static::isRegistered($name)) {
-            if ($manager->has($feedName) || $manager->has($entryName)) {
-                return;
-            }
-        }
-
         if (! static::hasExtension($name)) {
             throw new Exception\RuntimeException(sprintf(
                 'Could not load extension "%s" using Plugin Loader.'
@@ -595,9 +585,19 @@ class Reader implements ReaderImportInterface
             ));
         }
 
+        // Return early if already registered.
+        if (static::isRegistered($name)) {
+            return;
+        }
+
+        $manager   = static::getExtensionManager();
+
+        $feedName = $name . '\Feed';
         if ($manager->has($feedName)) {
             static::$extensions['feed'][] = $feedName;
         }
+
+        $entryName = $name . '\Entry';
         if ($manager->has($entryName)) {
             static::$extensions['entry'][] = $entryName;
         }

--- a/src/Writer/Renderer/AbstractRenderer.php
+++ b/src/Writer/Renderer/AbstractRenderer.php
@@ -222,11 +222,9 @@ class AbstractRenderer
         Writer\Writer::registerCoreExtensions();
         $manager = Writer\Writer::getExtensionManager();
         $all = Writer\Writer::getExtensions();
-        if (stripos(get_class($this), 'entry')) {
-            $exts = $all['entryRenderer'];
-        } else {
-            $exts = $all['feedRenderer'];
-        }
+        $exts = stripos(get_class($this), 'entry')
+            ? $all['entryRenderer']
+            : $all['feedRenderer'];
         foreach ($exts as $extension) {
             $plugin = $manager->get($extension);
             $plugin->setDataContainer($this->getDataContainer());

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -91,40 +91,36 @@ class Writer
      */
     public static function registerExtension($name)
     {
-        $feedName          = $name . '\Feed';
-        $entryName         = $name . '\Entry';
-        $feedRendererName  = $name . '\Renderer\Feed';
-        $entryRendererName = $name . '\Renderer\Entry';
-        $manager           = static::getExtensionManager();
-        if (static::isRegistered($name)) {
-            if ($manager->has($feedName)
-                || $manager->has($entryName)
-                || $manager->has($feedRendererName)
-                || $manager->has($entryRendererName)
-            ) {
-                return;
-            }
-        }
-        if (! $manager->has($feedName)
-            && ! $manager->has($entryName)
-            && ! $manager->has($feedRendererName)
-            && ! $manager->has($entryRendererName)
-        ) {
+        if (! static::hasExtension($name)) {
             throw new Exception\RuntimeException(sprintf(
-                'Could not load extension "%s" using Plugin Loader. '
-                . 'Check prefix paths are configured and extension exists.',
+                'Could not load extension "%s" using Plugin Loader.'
+                . ' Check prefix paths are configured and extension exists.',
                 $name
             ));
         }
+
+        if (static::isRegistered($name)) {
+            return;
+        }
+
+        $manager = static::getExtensionManager();
+
+        $feedName = $name . '\Feed';
         if ($manager->has($feedName)) {
             static::$extensions['feed'][] = $feedName;
         }
+
+        $entryName = $name . '\Entry';
         if ($manager->has($entryName)) {
             static::$extensions['entry'][] = $entryName;
         }
+
+        $feedRendererName = $name . '\Renderer\Feed';
         if ($manager->has($feedRendererName)) {
             static::$extensions['feedRenderer'][] = $feedRendererName;
         }
+
+        $entryRendererName = $name . '\Renderer\Entry';
         if ($manager->has($entryRendererName)) {
             static::$extensions['entryRenderer'][] = $entryRendererName;
         }
@@ -192,12 +188,56 @@ class Writer
         static::registerExtension('WellFormedWeb');
         static::registerExtension('Threading');
         static::registerExtension('ITunes');
-        static::registerExtension('GooglePlayPodcast');
+
+        // Added in 2.10.0; check for it conditionally
+        static::hasExtension('GooglePlayPodcast')
+            ? static::registerExtension('GooglePlayPodcast')
+            : trigger_error(
+                sprintf(
+                    'Please update your %1$s\ExtensionManagerInterface implementation to add entries for'
+                    . ' %1$s\Extension\GooglePlayPodcast\Entry,'
+                    . ' %1$s\Extension\GooglePlayPodcast\Feed,'
+                    . ' %1$s\Extension\GooglePlayPodcast\Renderer\Entry,'
+                    . ' and %1$s\Extension\GooglePlayPodcast\Renderer\Feed.',
+                    __NAMESPACE__
+                ),
+                \E_USER_NOTICE
+            );
     }
 
     public static function lcfirst($str)
     {
         $str[0] = strtolower($str[0]);
         return $str;
+    }
+
+    /**
+     * Does the extension manager have the named extension?
+     *
+     * This method exists to allow us to test if an extension is present in the
+     * extension manager. It may be used by registerExtension() to determine if
+     * the extension has items present in the manager, or by
+     * registerCoreExtension() to determine if the core extension has entries
+     * in the extension manager. In the latter case, this can be useful when
+     * adding new extensions in a minor release, as custom extension manager
+     * implementations may not yet have an entry for the extension, which would
+     * then otherwise cause registerExtension() to fail.
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected static function hasExtension($name)
+    {
+        $manager   = static::getExtensionManager();
+
+        $feedName          = $name . '\Feed';
+        $entryName         = $name . '\Entry';
+        $feedRendererName  = $name . '\Renderer\Feed';
+        $entryRendererName = $name . '\Renderer\Entry';
+
+        return $manager->has($feedName)
+            || $manager->has($entryName)
+            || $manager->has($feedRendererName)
+            || $manager->has($entryRendererName);
     }
 }

--- a/test/Reader/TestAsset/CustomExtensionManager.php
+++ b/test/Reader/TestAsset/CustomExtensionManager.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-feed for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-feed/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Feed\Reader\TestAsset;
+
+use Zend\Feed\Reader\Exception\InvalidArgumentException;
+use Zend\Feed\Reader\Extension;
+use Zend\Feed\Reader\ExtensionManagerInterface;
+
+/**
+ * Standalone extension manager that omits any extensions added after the 2.9 series.
+ */
+class CustomExtensionManager implements ExtensionManagerInterface
+{
+    private $extensions = [
+        'Atom\Entry'            => Extension\Atom\Entry::class,
+        'Atom\Feed'             => Extension\Atom\Feed::class,
+        'Content\Entry'         => Extension\Content\Entry::class,
+        'CreativeCommons\Entry' => Extension\CreativeCommons\Entry::class,
+        'CreativeCommons\Feed'  => Extension\CreativeCommons\Feed::class,
+        'DublinCore\Entry'      => Extension\DublinCore\Entry::class,
+        'DublinCore\Feed'       => Extension\DublinCore\Feed::class,
+        'Podcast\Entry'         => Extension\Podcast\Entry::class,
+        'Podcast\Feed'          => Extension\Podcast\Feed::class,
+        'Slash\Entry'           => Extension\Slash\Entry::class,
+        'Syndication\Feed'      => Extension\Syndication\Feed::class,
+        'Thread\Entry'          => Extension\Thread\Entry::class,
+        'WellFormedWeb\Entry'   => Extension\WellFormedWeb\Entry::class,
+    ];
+
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension)
+    {
+        return array_key_exists($extension, $this->extensions);
+    }
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return Extension\AbstractEntry|Extension\AbstractFeed
+     */
+    public function get($extension)
+    {
+        $class = $this->extensions[$extension];
+        return new $class();
+    }
+}

--- a/test/Writer/Renderer/Entry/RssTest.php
+++ b/test/Writer/Renderer/Entry/RssTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-feed for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-feed/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Feed\Writer\Renderer\Entry;
@@ -14,6 +12,7 @@ use Zend\Feed\Reader;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Exception\ExceptionInterface;
 use Zend\Feed\Writer\Renderer;
+use ZendTest\Feed\Writer\TestAsset;
 
 /**
  * @group      Zend_Feed
@@ -26,6 +25,7 @@ class RssTest extends TestCase
 
     public function setUp()
     {
+        Writer\Writer::reset();
         $this->validWriter = new Writer\Feed;
 
         $this->validWriter->setType('rss');
@@ -42,6 +42,7 @@ class RssTest extends TestCase
 
     public function tearDown()
     {
+        Writer\Writer::reset();
         $this->validWriter = null;
         $this->validEntry  = null;
     }
@@ -385,5 +386,35 @@ class RssTest extends TestCase
                   'scheme' => null]
         ];
         $this->assertEquals($expected, (array) $entry->getCategories());
+    }
+
+    public function testEntryRendererEmitsNoticeDuringInstantiationWhenGooglePlayPodcastExtensionUnavailable()
+    {
+        // Since we create feed and entry writer instances in the test constructor,
+        // we need to reset it _now_ before creating a new renderer.
+        Writer\Writer::reset();
+        Writer\Writer::setExtensionManager(new TestAsset\CustomExtensionManager());
+
+        $notices = (object) [
+            'messages' => [],
+        ];
+
+        set_error_handler(function ($errno, $errstr) use ($notices) {
+            $notices->messages[] = $errstr;
+        }, \E_USER_NOTICE);
+        $renderer = new Renderer\Entry\Rss($this->validEntry);
+        restore_error_handler();
+
+        $message = array_reduce($notices->messages, function ($toReturn, $message) {
+            if ('' !== $toReturn) {
+                return $toReturn;
+            }
+            return false === strstr($message, 'GooglePlayPodcast') ? '' : $message;
+        }, '');
+
+        $this->assertNotEmpty(
+            $message,
+            'GooglePlayPodcast extension was present in extension manager, but was not expected to be'
+        );
     }
 }

--- a/test/Writer/TestAsset/CustomExtensionManager.php
+++ b/test/Writer/TestAsset/CustomExtensionManager.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-feed for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-feed/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Feed\Writer\TestAsset;
+
+use Zend\Feed\Writer\Exception\InvalidArgumentException;
+use Zend\Feed\Writer\Extension;
+use Zend\Feed\Writer\ExtensionManagerInterface;
+
+class CustomExtensionManager implements ExtensionManagerInterface
+{
+    private $extensions = [
+        'Atom\Renderer\Feed'           => Extension\Atom\Renderer\Feed::class,
+        'Content\Renderer\Entry'       => Extension\Content\Renderer\Entry::class,
+        'DublinCore\Renderer\Entry'    => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCore\Renderer\Feed'     => Extension\DublinCore\Renderer\Feed::class,
+        'ITunes\Entry'                 => Extension\ITunes\Entry::class,
+        'ITunes\Feed'                  => Extension\ITunes\Feed::class,
+        'ITunes\Renderer\Entry'        => Extension\ITunes\Renderer\Entry::class,
+        'ITunes\Renderer\Feed'         => Extension\ITunes\Renderer\Feed::class,
+        'Slash\Renderer\Entry'         => Extension\Slash\Renderer\Entry::class,
+        'Threading\Renderer\Entry'     => Extension\Threading\Renderer\Entry::class,
+        'WellFormedWeb\Renderer\Entry' => Extension\WellFormedWeb\Renderer\Entry::class,
+    ];
+
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension)
+    {
+        return array_key_exists($extension, $this->extensions);
+    }
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return mixed
+     */
+    public function get($extension)
+    {
+        $class = $this->has($extension) ? $this->extensions[$extension] : false;
+        if (! $class) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot fetch extension "%s"; class "%s" does not exist',
+                $extension,
+                $class
+            ));
+        }
+        return new $class();
+    }
+}


### PR DESCRIPTION
Custom implementations of `ExtensionManagerInterface` may not have _new core_ extensions present. As a result, when upgrading, an exception is thrown due to inability to load the new extension.

This was discovered with the 2.10 release, when we added a new core extension, GooglePlayPodcast; see #80 and https://www.drupal.org/project/drupal/issues/2976335 for more details.

As such, we now check for _new_ core extensions before registering them.  When we discover they are not in the extension manager, we emit an `E_USER_NOTICE` indicating the user should update their `ExtensionManagerInterface` implementation to add entries for the new extension, but then continue on without registering the extension. This ensures no exception is thrown.