### PR TITLE
Added Reader/Writer methods and tests for <itunes:title> on entry level

### DIFF
--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -130,6 +130,28 @@ class Entry extends Extension\AbstractEntry
     }
 
     /**
+     * Get the entry title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        if (isset($this->data['title'])) {
+            return $this->data['title'];
+        }
+
+        $title = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/itunes:title)');
+
+        if (! $title) {
+            $title = null;
+        }
+
+        $this->data['title'] = $title;
+
+        return $this->data['title'];
+    }
+
+    /**
      * Get the entry subtitle
      *
      * @return string

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -192,6 +192,23 @@ class Entry
     }
 
     /**
+     * Set title
+     *
+     * @param  string $value
+     * @return Entry
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setItunesTitle($value)
+    {
+        if ($this->stringWrapper->strlen($value) > 255) {
+            throw new Writer\Exception\InvalidArgumentException('invalid parameter: "title" may only'
+            . ' contain a maximum of 255 characters');
+        }
+        $this->data['title'] = $value;
+        return $this;
+    }
+
+    /**
      * Set subtitle
      *
      * @param  string $value

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -39,6 +39,7 @@ class Entry extends Extension\AbstractRenderer
         $this->_setImage($this->dom, $this->base);
         $this->_setExplicit($this->dom, $this->base);
         $this->_setKeywords($this->dom, $this->base);
+        $this->_setTitle($this->dom, $this->base);
         $this->_setSubtitle($this->dom, $this->base);
         $this->_setSummary($this->dom, $this->base);
         $this->_setEpisode($this->dom, $this->base);
@@ -193,6 +194,28 @@ class Entry extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('itunes:keywords');
         $text = $dom->createTextNode(implode(',', $keywords));
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set entry title
+     *
+     * @param  DOMDocument $dom
+     * @param  DOMElement $root
+     * @return void
+     */
+    // @codingStandardsIgnoreStart
+    protected function _setTitle(DOMDocument $dom, DOMElement $root)
+    {
+        // @codingStandardsIgnoreEnd
+        $title = $this->getDataContainer()->getItunesTitle();
+        if (! $title) {
+            return;
+        }
+        $el = $dom->createElement('itunes:title');
+        $text = $dom->createTextNode($title);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/test/Reader/Integration/_files/google-podcast-complete.xml
+++ b/test/Reader/Integration/_files/google-podcast-complete.xml
@@ -40,6 +40,7 @@
 			<googleplay:explicit>no</googleplay:explicit>
             <itunes:author>John Doe</itunes:author>
 			<googleplay:block>yes</googleplay:block>
+            <itunes:title>Shake Shake Shake Your Spices With A Shaker</itunes:title>
             <itunes:subtitle>A short primer on table spices
             </itunes:subtitle>
             <googleplay:description>This week we talk about salt and pepper
@@ -59,6 +60,7 @@
         <item>
             <title>Socket Wrench Shootout</title>
             <itunes:author>Jane Doe</itunes:author>
+            <itunes:title>Socket Wrench Shootout With A Tool</itunes:title>
             <itunes:subtitle>Comparing socket wrenches is fun!
             </itunes:subtitle>
             <googleplay:description>This week we talk about metric vs. old
@@ -78,6 +80,7 @@
         <item>
             <title>Red, Whine, &amp; Blue</title>
             <itunes:author>Various</itunes:author>
+            <itunes:title>Red, Whine &amp; Blue</itunes:title>
             <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
             <googleplay:description>This week we talk about surviving in a Red
                 state if you are a Blue person. Or vice versa.

--- a/test/Reader/Integration/_files/google-podcast.xml
+++ b/test/Reader/Integration/_files/google-podcast.xml
@@ -39,6 +39,7 @@
 			<googleplay:explicit>no</googleplay:explicit>
             <itunes:author>John Doe</itunes:author>
 			<googleplay:block>yes</googleplay:block>
+            <itunes:title>Shake Shake Shake Your Spices With A Shaker</itunes:title>
             <itunes:subtitle>A short primer on table spices
             </itunes:subtitle>
             <googleplay:description>This week we talk about salt and pepper
@@ -60,6 +61,7 @@
         <item>
             <title>Socket Wrench Shootout</title>
             <itunes:author>Jane Doe</itunes:author>
+            <itunes:title>Socket Wrench Shootout With A Tool</itunes:title>
             <itunes:subtitle>Comparing socket wrenches is fun!
             </itunes:subtitle>
             <googleplay:description>This week we talk about metric vs. old
@@ -81,6 +83,7 @@
         <item>
             <title>Red, Whine, &amp; Blue</title>
             <itunes:author>Various</itunes:author>
+            <itunes:title>Red, Whine &amp; Blue</itunes:title>
             <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
             <googleplay:description>This week we talk about surviving in a Red
                 state if you are a Blue person. Or vice versa.

--- a/test/Reader/Integration/_files/podcast-complete.xml
+++ b/test/Reader/Integration/_files/podcast-complete.xml
@@ -38,6 +38,7 @@
 			<itunes:explicit>no</itunes:explicit>
             <itunes:author>John Doe</itunes:author>
 			<itunes:block>yes</itunes:block>
+            <itunes:title>Shake Shake Shake Your Spices With A Shaker</itunes:title>
             <itunes:subtitle>A short primer on table spices
             </itunes:subtitle>
             <itunes:summary>This week we talk about salt and pepper
@@ -57,6 +58,7 @@
         <item>
             <title>Socket Wrench Shootout</title>
             <itunes:author>Jane Doe</itunes:author>
+            <itunes:title>Socket Wrench Shootout With A Tool</itunes:title>
             <itunes:subtitle>Comparing socket wrenches is fun!
             </itunes:subtitle>
             <itunes:summary>This week we talk about metric vs. old
@@ -76,6 +78,7 @@
         <item>
             <title>Red, Whine, &amp; Blue</title>
             <itunes:author>Various</itunes:author>
+            <itunes:title>Red, Whine &amp; Blue</itunes:title>
             <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
             <itunes:summary>This week we talk about surviving in a Red
                 state if you are a Blue person. Or vice versa.

--- a/test/Reader/Integration/_files/podcast-episode.xml
+++ b/test/Reader/Integration/_files/podcast-episode.xml
@@ -39,6 +39,7 @@
 			<itunes:explicit>no</itunes:explicit>
             <itunes:author>John Doe</itunes:author>
 			<itunes:block>yes</itunes:block>
+            <itunes:title>Shake Shake Shake Your Spices With A Shaker</itunes:title>
             <itunes:subtitle>A short primer on table spices
             </itunes:subtitle>
             <itunes:summary>This week we talk about salt and pepper
@@ -58,6 +59,7 @@
         <item>
             <title>Socket Wrench Shootout</title>
             <itunes:author>Jane Doe</itunes:author>
+            <itunes:title>Socket Wrench Shootout With A Tool</itunes:title>
             <itunes:subtitle>Comparing socket wrenches is fun!
             </itunes:subtitle>
             <itunes:summary>This week we talk about metric vs. old
@@ -77,6 +79,7 @@
         <item>
             <title>Red, Whine, &amp; Blue</title>
             <itunes:author>Various</itunes:author>
+            <itunes:title>Red, Whine &amp; Blue</itunes:title>
             <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
             <itunes:summary>This week we talk about surviving in a Red
                 state if you are a Blue person. Or vice versa.

--- a/test/Reader/Integration/_files/podcast.xml
+++ b/test/Reader/Integration/_files/podcast.xml
@@ -37,6 +37,7 @@
 			<itunes:explicit>no</itunes:explicit>
             <itunes:author>John Doe</itunes:author>
 			<itunes:block>yes</itunes:block>
+            <itunes:title>Shake Shake Shake Your Spices With A Shaker</itunes:title>
             <itunes:subtitle>A short primer on table spices
             </itunes:subtitle>
             <itunes:summary>This week we talk about salt and pepper
@@ -58,6 +59,7 @@
         <item>
             <title>Socket Wrench Shootout</title>
             <itunes:author>Jane Doe</itunes:author>
+            <itunes:title>Socket Wrench Shootout With A Tool</itunes:title>
             <itunes:subtitle>Comparing socket wrenches is fun!
             </itunes:subtitle>
             <itunes:summary>This week we talk about metric vs. old
@@ -79,6 +81,7 @@
         <item>
             <title>Red, Whine, &amp; Blue</title>
             <itunes:author>Various</itunes:author>
+            <itunes:title>Red, Whine &amp; Blue</itunes:title>
             <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
             <itunes:summary>This week we talk about surviving in a Red
                 state if you are a Blue person. Or vice versa.

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -185,6 +185,20 @@ class EntryTest extends TestCase
         }
     }
 
+    public function testSetTitle()
+    {
+        $entry = new Writer\Entry;
+        $entry->setItunesTitle('abc');
+        $this->assertEquals('abc', $entry->getItunesTitle());
+    }
+
+    public function testSetTitleThrowsExceptionWhenValueExceeds255Chars()
+    {
+        $this->expectException(ExceptionInterface::class);
+        $entry = new Writer\Entry;
+        $entry->setItunesTitle(str_repeat('a', 256));
+    }
+
     public function testSetSubtitle()
     {
         $entry = new Writer\Entry;


### PR DESCRIPTION
There is a (new) field in the Itunes podcast spec for the episode title. 
See https://help.apple.com/itc/podcasts_connect/#/itcb54353390 > **Episode descriptions** > <itunes:title>

The pull requests adds the missing methods for reading and writing a feed and the tests.
