### PR TITLE
Marks old and unused reader classes as deprecated

### DIFF
--- a/src/Reader/AbstractEntry.php
+++ b/src/Reader/AbstractEntry.php
@@ -13,6 +13,9 @@ use DOMDocument;
 use DOMElement;
 use DOMXPath;
 
+/**
+ * @deprecated This (abstract) class is deprecated. Use Zend\Feed\Reader\Entry\AbstractEntry instead.
+ */
 abstract class AbstractEntry
 {
     /**

--- a/src/Reader/AbstractFeed.php
+++ b/src/Reader/AbstractFeed.php
@@ -13,6 +13,9 @@ use DOMDocument;
 use DOMElement;
 use DOMXPath;
 
+/**
+ * @deprecated This (abstract) class is deprecated. Use \Zend\Feed\Reader\Feed\AbstractFeed instead.
+ */
 abstract class AbstractFeed implements Feed\FeedInterface
 {
     /**

--- a/src/Reader/Collection.php
+++ b/src/Reader/Collection.php
@@ -11,6 +11,11 @@ namespace Zend\Feed\Reader;
 
 use ArrayObject;
 
+/**
+ * @deprecated This class is deprecated. Use the concret collection classes
+ *             \Zend\Feed\Reader\Collection\Author and \Zend\Feed\Reader\Collection\Category
+ *             or the generic class \Zend\Feed\Reader\Collection\Collection instead
+ */
 class Collection extends ArrayObject
 {
 }


### PR DESCRIPTION
These classes are deprecated:

* `Zend\Feed\Reader\AbstractEntry`
* `Zend\Feed\Reader\AbstractFeed`
* `Zend\Feed\Reader\Collection`